### PR TITLE
Adds cloud sql enforces ssl connection action

### DIFF
--- a/clients/stubs/cloudsql.go
+++ b/clients/stubs/cloudsql.go
@@ -29,10 +29,15 @@ type SQLAdminStub struct {
 	SavedInstanceUpdated *sqladmin.DatabaseInstance
 }
 
+// WaitSQL waits globally.
+func (s *SQLAdminStub) WaitSQL(project string, op *sqladmin.Operation) []error {
+	return []error{}
+}
+
 // PatchInstance updates partialy a cloud sql instance.
-func (s *SQLAdminStub) PatchInstance(ctx context.Context, project string, instance string, databaseInstance *sqladmin.DatabaseInstance) (*sqladmin.Operation, error) {
+func (s *SQLAdminStub) PatchInstance(ctx context.Context, projectID string, instance string, databaseInstance *sqladmin.DatabaseInstance) (*sqladmin.Operation, error) {
 	s.SavedInstanceUpdated = databaseInstance
-	if project == "nonexisting" || instance == "nonexisting" || databaseInstance.Name == "nonexisting" {
+	if projectID == "nonexisting" || instance == "nonexisting" || databaseInstance.Name == "nonexisting" {
 		return nil, ErrResourceNonExistent
 	}
 

--- a/entities/cloudsql.go
+++ b/entities/cloudsql.go
@@ -23,6 +23,7 @@ import (
 // CloudSQLClient contains minimum interface required by the cloud sql entity.
 type CloudSQLClient interface {
 	PatchInstance(context.Context, string, string, *sqladmin.DatabaseInstance) (*sqladmin.Operation, error)
+	WaitSQL(projectID string, op *sqladmin.Operation) []error
 }
 
 // CloudSQL entity.
@@ -35,12 +36,17 @@ func NewCloudSQL(cc CloudSQLClient) *CloudSQL {
 	return &CloudSQL{client: cc}
 }
 
+// WaitSQL will wait for the SQL operation to complete.
+func (s *CloudSQL) WaitSQL(project string, op *sqladmin.Operation) []error {
+	return s.client.WaitSQL(project, op)
+}
+
 // EnforceSSLConnection enforces SSL Connection to a database.
-func (s *CloudSQL) EnforceSSLConnection(ctx context.Context, project string, instance string, region string) (*sqladmin.Operation, error) {
-	return s.client.PatchInstance(ctx, project, instance, &sqladmin.DatabaseInstance{
+func (s *CloudSQL) EnforceSSLConnection(ctx context.Context, projectID string, instance string, region string) (*sqladmin.Operation, error) {
+	return s.client.PatchInstance(ctx, projectID, instance, &sqladmin.DatabaseInstance{
 		Name:           instance,
-		Project:        project,
-		ConnectionName: project + ":" + region + ":" + instance,
+		Project:        projectID,
+		ConnectionName: projectID + ":" + region + ":" + instance,
 		Settings: &sqladmin.Settings{
 			IpConfiguration: &sqladmin.IpConfiguration{
 				RequireSsl: true,

--- a/entities/cloudsql_test.go
+++ b/entities/cloudsql_test.go
@@ -27,7 +27,7 @@ func TestEnforceSSLConnection(t *testing.T) {
 	tests := []struct {
 		name             string
 		instance         string
-		project          string
+		projectID        string
 		region           string
 		expectedError    error
 		expectedResponse *sqladmin.Operation
@@ -37,7 +37,7 @@ func TestEnforceSSLConnection(t *testing.T) {
 		{
 			name:             "enforce ssl connection in a existing database",
 			instance:         "instance1",
-			project:          "project1",
+			projectID:        "project1",
 			region:           "us-central1",
 			expectedError:    nil,
 			expectedResponse: nil,
@@ -55,7 +55,7 @@ func TestEnforceSSLConnection(t *testing.T) {
 		{
 			name:             "enforce ssl connection in a nonexisting database",
 			instance:         "unexisting",
-			project:          "project1",
+			projectID:        "project1",
 			region:           "us-central1",
 			expectedError:    nil,
 			expectedResponse: nil,
@@ -77,7 +77,7 @@ func TestEnforceSSLConnection(t *testing.T) {
 			sqlAdminStub := &stubs.SQLAdminStub{}
 			ctx := context.Background()
 			c := NewCloudSQL(sqlAdminStub)
-			r, err := c.EnforceSSLConnection(ctx, tt.project, tt.instance, tt.region)
+			r, err := c.EnforceSSLConnection(ctx, tt.projectID, tt.instance, tt.region)
 
 			if diff := cmp.Diff(sqlAdminStub.SavedInstanceUpdated, tt.expectedRequest); diff != "" {
 				t.Errorf("%v failed, difference: %+v", tt.name, diff)


### PR DESCRIPTION
Hi Tom!

This pull request refer to the issue #27, and this PR only adds the action for it.

As we talked, in this PR i had to add a new wait code, it's "equal" to the compute wait function, changing only the operation type expected (from compute or from sql).

I'm creating a new issue (#29) to do a refactor of this code.