### PR TITLE
Add missing logging.Writer role to service account

### DIFF
--- a/automations/modules/google-setup/main.tf
+++ b/automations/modules/google-setup/main.tf
@@ -81,7 +81,6 @@ resource "google_organization_iam_binding" "cscc-notifications-sa" {
 
 resource "google_project_iam_member" "stackdriver-writer" {
   project = "${var.automation-project}"
-  role   = "roles/logging.logWriter"
-
-  member = "serviceAccount:${google_service_account.automation-service-account.email}"
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.automation-service-account.email}"
 }


### PR DESCRIPTION
The logger client needs role "roles/logging.logWriter" and the bind to the service account on the automation project is missing form the Terraform config file