### PR TITLE
Replace google_X_iam_binding with google_X_iam_member in Terraform configuration files.

### DIFF
--- a/automations/close-public-bucket/main.tf
+++ b/automations/close-public-bucket/main.tf
@@ -34,19 +34,19 @@ resource "google_cloudfunctions_function" "close-bucket" {
 }
 
 # Required to retrieve ancestry for projects within this folder.
-resource "google_folder_iam_binding" "roles-viewer" {
+resource "google_folder_iam_member" "roles-viewer" {
   count = length(var.folder-ids)
 
-  folder  = "folders/${var.folder-ids[count.index]}"
-  role    = "roles/viewer"
-  members = ["serviceAccount:${var.automation-service-account}"]
+  folder = "folders/${var.folder-ids[count.index]}"
+  role   = "roles/viewer"
+  member = "serviceAccount:${var.automation-service-account}"
 }
 
 # Required to modify buckets within this folder.
-resource "google_folder_iam_binding" "roles-storage-admin" {
+resource "google_folder_iam_member" "roles-storage-admin" {
   count = length(var.folder-ids)
 
-  folder  = "folders/${var.folder-ids[count.index]}"
-  role    = "roles/storage.admin"
-  members = ["serviceAccount:${var.automation-service-account}"]
+  folder = "folders/${var.folder-ids[count.index]}"
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${var.automation-service-account}"
 }

--- a/automations/create-disk-snapshot/main.tf
+++ b/automations/create-disk-snapshot/main.tf
@@ -37,9 +37,8 @@ resource "google_cloudfunctions_function" "create-disk-snapshot" {
 # being used.
 #
 # TODO: Support folder level grants.
-resource "google_organization_iam_binding" "gce-snapshot-bind-findings-organization" {
+resource "google_organization_iam_member" "gce-snapshot-bind-findings-organization" {
   org_id = "${var.organization-id}"
   role   = "roles/compute.instanceAdmin.v1"
-
-  members = ["serviceAccount:${var.automation-service-account}"]
+  member = "serviceAccount:${var.automation-service-account}"
 }

--- a/automations/modules/google-setup/main.tf
+++ b/automations/modules/google-setup/main.tf
@@ -48,13 +48,10 @@ resource "google_logging_project_sink" "sink" {
   project                = "${var.findings-project}"
 }
 
-resource "google_project_iam_binding" "log-writer-pubsub" {
+resource "google_project_iam_member" "log-writer-pubsub" {
   role    = "roles/pubsub.publisher"
   project = "${var.automation-project}"
-
-  members = [
-    "${google_logging_project_sink.sink.writer_identity}",
-  ]
+  member  = "${google_logging_project_sink.sink.writer_identity}"
 }
 
 resource "google_pubsub_topic" "topic" {
@@ -72,9 +69,8 @@ resource "google_pubsub_subscription" "cscc-notifications-subscription" {
   ack_deadline_seconds = 20
 }
 
-resource "google_organization_iam_binding" "cscc-notifications-sa" {
+resource "google_organization_iam_member" "cscc-notifications-sa" {
   org_id = "${var.organization-id}"
   role   = "roles/securitycenter.notificationConfigEditor"
-
-  members = ["serviceAccount:${google_service_account.automation-service-account.email}"]
+  member = "serviceAccount:${google_service_account.automation-service-account.email}"
 }

--- a/automations/revoke-iam-grants/main.tf
+++ b/automations/revoke-iam-grants/main.tf
@@ -37,12 +37,12 @@ resource "google_cloudfunctions_function" "revoke_member_function" {
 }
 
 # Required by RevokeExternalGrantsFolders to revoke IAM grants on projects within this folder.
-resource "google_folder_iam_binding" "revoke_member_cloudfunction-folder-bind" {
+resource "google_folder_iam_member" "revoke_member_cloudfunction-folder-bind" {
   count = length(var.folder-ids)
 
-  folder  = "folders/${var.folder-ids[count.index]}"
-  role    = "roles/resourcemanager.folderAdmin"
-  members = ["serviceAccount:${var.automation-service-account}"]
+  folder = "folders/${var.folder-ids[count.index]}"
+  role   = "roles/resourcemanager.folderAdmin"
+  member = "serviceAccount:${var.automation-service-account}"
 }
 
 # In order for this GCF to be able to enumerate and check to see if the affected project is within
@@ -53,10 +53,10 @@ resource "google_folder_iam_binding" "revoke_member_cloudfunction-folder-bind" {
 # or let it fail which also means the project is outside of the folder you care about.
 #
 # In this example we'll grant `roles/viewer` which has this permission to the folder.
-resource "google_folder_iam_binding" "revoke_member_viewer_cloudfunction-folder-bind" {
+resource "google_folder_iam_member" "revoke_member_viewer_cloudfunction-folder-bind" {
   count = length(var.folder-ids)
 
-  folder  = "folders/${var.folder-ids[count.index]}"
-  role    = "roles/viewer"
-  members = ["serviceAccount:${var.automation-service-account}"]
+  folder = "folders/${var.folder-ids[count.index]}"
+  role   = "roles/viewer"
+  member = "serviceAccount:${var.automation-service-account}"
 }


### PR DESCRIPTION
**"google_X_iam_binding"** overwrites the binding, deleting the previous bounded users, groups and service accounts.

**"google_X_iam_member"**  just add the selected service account to the current existing binding, without removing existing users