### PR TITLE
Unify error handling for ETD Findings

### DIFF
--- a/cloudfunctions/revoke_external_grants_folders.go
+++ b/cloudfunctions/revoke_external_grants_folders.go
@@ -17,12 +17,12 @@ package cloudfunctions
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 
 	"github.com/googlecloudplatform/threat-automation/entities"
 	"github.com/googlecloudplatform/threat-automation/providers/etd"
+	"github.com/pkg/errors"
 
 	"cloud.google.com/go/pubsub"
 )
@@ -39,14 +39,14 @@ import (
 func RevokeExternalGrantsFolders(ctx context.Context, m pubsub.Message, r *entities.Resource, folderIDs []string, disallowed []string, l *entities.Logger) error {
 	f, err := etd.NewExternalMembersFinding(&m)
 	if err != nil {
-		return fmt.Errorf("failed to read finding: %q", err)
+		return errors.Wrap(err, "failed to read finding")
 	}
 
 	log.Printf("listing project %q ancestors", f.ProjectID())
 
 	ancestors, err := r.GetProjectAncestry(ctx, f.ProjectID())
 	if err != nil {
-		return fmt.Errorf("failed to get project ancestry: %q", err)
+		return errors.Wrap(err, "failed to get project ancestry")
 	}
 
 	log.Printf("ancestors returned from project %q: %v", f.ProjectID(), ancestors)
@@ -61,7 +61,7 @@ func RevokeExternalGrantsFolders(ctx context.Context, m pubsub.Message, r *entit
 			l.Info("removing users %v from folder %q project %q", remove, folderID, f.ProjectID())
 
 			if _, err = r.RemoveMembersProject(ctx, f.ProjectID(), remove); err != nil {
-				return fmt.Errorf("failed to remove disallowed domains: %q", err)
+				return errors.Wrap(err, "failed to remove disallowed domains")
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	golang.org/x/lint v0.0.0-20190930215403-16217165b5de // indirect
 	golang.org/x/tools v0.0.0-20191010201905-e5ffc44a6fee // indirect
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	google.golang.org/api v0.10.0
 	google.golang.org/genproto v0.0.0-20190905072037-92dd089d5514
 	google.golang.org/grpc v1.21.1

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ golang.org/x/tools v0.0.0-20190930201159-7c411dea38b0 h1:7+F62GGWUowoiJOUDivedlB
 golang.org/x/tools v0.0.0-20190930201159-7c411dea38b0/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191010201905-e5ffc44a6fee h1:Cgj5oVkw7Gktu56MAiU0r1u0jyuT6jmtOzcAJwLj89c=
 golang.org/x/tools v0.0.0-20191010201905-e5ffc44a6fee/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0 h1:9sdfJOzWlkqPltHAuzT2Cp+yrBeY1KRVYgms8soxMwM=

--- a/providers/etd/anomalous_iam_grant.go
+++ b/providers/etd/anomalous_iam_grant.go
@@ -37,14 +37,15 @@ type ExternalMembersFinding struct {
 // NewExternalMembersFinding reads a pubsub message and creates a new finding.
 func NewExternalMembersFinding(ps *pubsub.Message) (*ExternalMembersFinding, error) {
 	var f ExternalMembersFinding
-	if err := json.Unmarshal(ps.Data, &f.fields); err != nil {
-		return nil, entities.ErrUnmarshal
-	}
 	b, err := NewFinding(ps)
 	if err != nil {
 		return nil, err
 	}
 	f.Finding = b
+	if err := json.Unmarshal(ps.Data, &f.fields); err != nil {
+		return nil, errors.Wrap(entities.ErrUnmarshal, err.Error())
+	}
+
 	if v := f.validate(); !v {
 		return nil, errors.Wrap(entities.ErrValueNotFound, "fields did not validate")
 	}

--- a/providers/etd/bad_ip.go
+++ b/providers/etd/bad_ip.go
@@ -36,14 +36,14 @@ type BadIP struct {
 // NewBadIP reads a pubsub message and creates a new finding.
 func NewBadIP(ps *pubsub.Message) (*BadIP, error) {
 	var f BadIP
-	if err := json.Unmarshal(ps.Data, &f.fields); err != nil {
-		return nil, errors.Wrap(entities.ErrUnmarshal, err.Error())
-	}
 	b, err := NewFinding(ps)
 	if err != nil {
 		return nil, err
 	}
 	f.Finding = b
+	if err := json.Unmarshal(ps.Data, &f.fields); err != nil {
+		return nil, errors.Wrap(entities.ErrUnmarshal, err.Error())
+	}
 	if v := f.validate(); !v {
 		return nil, errors.Wrap(entities.ErrValueNotFound, "fields did not validate")
 	}

--- a/providers/etd/findings_test.go
+++ b/providers/etd/findings_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/googlecloudplatform/threat-automation/entities"
+	"golang.org/x/xerrors"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ func TestForFailures(t *testing.T) {
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := NewBadIP(tt.message)
-			if err != nil && errors.Cause(err).Error() != tt.exp.Error() {
+			if !xerrors.Is(errors.Cause(err), tt.exp) {
 				t.Errorf("%s failed got:%q want:%q", tt.name, err, tt.exp)
 			}
 		})


### PR DESCRIPTION
- Use  `errors.Wrap` instead of `fmt.Errorf`  in `cloudfunctions/revoke_external_grants_folders_test.go` 
- Do not eat up base finding errors on `BadIP` and `ExternalMembersFinding`
- Check for base finding errors before checking for `BadIP` and `ExternalMembersFinding` errors
- Change test to expect for the error from `entities.Err*`, not an error string 


Note: changes from  `errors.Wrap` to `fmt.Errorf`  in `cloudfunctions/create_snapshot.go` and `cloudfunctions/close_bucket.go` will be sent in another PR