### PR TITLE
Add template service

### DIFF
--- a/clients/sendgrid.go
+++ b/clients/sendgrid.go
@@ -16,28 +16,15 @@ package clients
 
 import (
 	"fmt"
-
 	"github.com/sendgrid/rest"
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 )
 
-// General email interface and response -----------------------------------/
 const (
-	// emailSender name used as sender
+	// emailSender name used as sender.
 	emailSender = "Security Response Automation"
 )
-
-// EmailClient is the interface used for sending emails.
-type EmailClient interface {
-	Send(subject, from, body string, to []string) (*EmailResponse, error)
-}
-
-// EmailResponse email response data.
-type EmailResponse struct {
-	StatusCode int
-	Body       string
-}
 
 // SendGridClient client provider -------------------------------------------------/
 type SendGridClient interface {
@@ -55,7 +42,7 @@ func NewSendGridClient(apiKey string) *SendGrid {
 }
 
 // Send email SendGrid.
-func (s *SendGrid) Send(subject, from, body string, to []string) (*EmailResponse, error) {
+func (s *SendGrid) Send(subject, from, body string, to []string) (*rest.Response, error) {
 	e := createEmail(subject, from, body, emailSender, to)
 	r, err := s.Service.Send(e)
 
@@ -67,7 +54,7 @@ func (s *SendGrid) Send(subject, from, body string, to []string) (*EmailResponse
 		return nil, fmt.Errorf("Error to send email. StatusCode:(%d)", r.StatusCode)
 	}
 
-	return &EmailResponse{StatusCode: r.StatusCode, Body: r.Body}, err
+	return r, err
 }
 
 func createEmail(subject, from, body, sender string, to []string) *mail.SGMailV3 {

--- a/clients/sendgrid_test.go
+++ b/clients/sendgrid_test.go
@@ -1,5 +1,19 @@
 package clients
 
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import (
 	"testing"
 
@@ -7,8 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sendgrid/rest"
 )
-
-//
 
 func TestClientSendGridSendEmail(t *testing.T) {
 	tests := []struct {

--- a/entities/email.go
+++ b/entities/email.go
@@ -14,19 +14,64 @@ package entities
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import "github.com/googlecloudplatform/threat-automation/clients"
+import (
+	"bytes"
+	"github.com/pkg/errors"
+	"github.com/sendgrid/rest"
+	"html/template"
+	"path/filepath"
+)
+
+const templatesPath = "../templates/"
+
+var (
+	// errLoadTemplate error on load template file.
+	errLoadTemplate = errors.New("Error on load template file")
+
+	// errParseTemplate error on set the template content values.
+	errParseTemplate = errors.New("Error on parse template")
+)
+
+// EmailClient is the interface used for sending emails.
+type EmailClient interface {
+	Send(subject, from, body string, to []string) (*rest.Response, error)
+}
+
+// EmailResponse contains the response from sending an email.
+type EmailResponse struct {
+	StatusCode int
+	Body       string
+}
 
 // Email is the entity used to send emails.
 type Email struct {
-	service clients.EmailClient
+	service EmailClient
 }
 
 // NewEmail creates a new email entity.
-func NewEmail(service clients.EmailClient) *Email {
+func NewEmail(service EmailClient) *Email {
 	return &Email{service: service}
 }
 
 // Send will send an email.
-func (m *Email) Send(subject, from, body string, to []string) (*clients.EmailResponse, error) {
+func (m *Email) Send(subject, from, body string, to []string) (*rest.Response, error) {
 	return m.service.Send(subject, from, body, to)
+}
+
+// RenderTemplate parses the content based on template.
+func (m *Email) RenderTemplate(templateName string, templateContent interface{}) (string, error) {
+	fileName := filepath.Join(templatesPath, templateName)
+	file, err := template.ParseGlob(fileName)
+
+	if err != nil {
+		return "", errors.Wrap(errLoadTemplate, err.Error())
+	}
+
+	out := &bytes.Buffer{}
+
+	if err := file.Execute(out, templateContent); err != nil {
+		return "", errors.Wrap(errParseTemplate, err.Error())
+	}
+
+	return out.String(), nil
 }

--- a/entities/email_test.go
+++ b/entities/email_test.go
@@ -1,0 +1,75 @@
+package entities
+
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"testing"
+)
+
+func TestParseTemplateEmail(t *testing.T) {
+
+	var sampleTemplate = "%s Admin,\nSecurity Response Automation"
+
+	type sampleContent struct {
+		Greeting string
+	}
+
+	tests := []struct {
+		name             string
+		expectedError    error
+		expectedResponse string
+		template         string
+		templateContent  interface{}
+	}{
+		{
+			name:             "test parse email success",
+			template:         "testdata/sample.tmpl",
+			templateContent:  struct{ Content sampleContent }{Content: sampleContent{Greeting: "Hello!"}},
+			expectedError:    nil,
+			expectedResponse: fmt.Sprintf(sampleTemplate, "Hello!"),
+		},
+		{
+			name:             "test parse not found file",
+			template:         "testdata/unknown.tmpl",
+			templateContent:  nil,
+			expectedError:    errLoadTemplate,
+			expectedResponse: "",
+		},
+		{
+			name:             "test parse execution fail",
+			template:         "testdata/sample.tmpl",
+			templateContent:  struct{ Unknown string }{Unknown: "content"},
+			expectedError:    errParseTemplate,
+			expectedResponse: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			email := NewEmail(nil)
+			res, err := email.RenderTemplate(tt.template, tt.templateContent)
+
+			if tt.expectedError != errors.Cause(err) {
+				t.Errorf("%v failed exp:%v got:%v", tt.name, tt.expectedError, err)
+			}
+
+			if exp, got := tt.expectedResponse, res; err == nil && exp != got {
+				t.Errorf("%v failed exp:%v got:%v", tt.name, got, exp)
+			}
+		})
+	}
+}

--- a/providers/sha/compute_instance_scanner.go
+++ b/providers/sha/compute_instance_scanner.go
@@ -34,7 +34,7 @@ type ComputeInstanceScanner struct {
 	*Finding
 }
 
-// NewFirewallScanner creates a new FirewallScanner
+// NewComputeInstanceScanner creates a new FirewallScanner.
 func NewComputeInstanceScanner(ps *pubsub.Message) (*ComputeInstanceScanner, error) {
 	f := ComputeInstanceScanner{}
 

--- a/providers/sha/findings_test.go
+++ b/providers/sha/findings_test.go
@@ -119,7 +119,7 @@ const (
   }
 }`
 
-	publicIpAddressFinding = `{
+	publicIPAddressFinding = `{
   "notificationConfigName": "organizations/154584661726/notificationConfigs/sampleConfigId",
   "finding": {
 	"name": "organizations/1055058813388/sources/1986930501971458034/findings/d7ef72093c8c1e4c135d4c43fa847b83",
@@ -335,7 +335,7 @@ func TestForShaComputeInstanceScanner(t *testing.T) {
 	}{
 		{
 			name:        "valid SHA Compute Instance Scanner finding",
-			message:     &pubsub.Message{Data: []byte(publicIpAddressFinding)},
+			message:     &pubsub.Message{Data: []byte(publicIPAddressFinding)},
 			expZone:     "us-central1-a",
 			expInstance: "4312755253150365851",
 		},

--- a/templates/testdata/sample.tmpl
+++ b/templates/testdata/sample.tmpl
@@ -1,0 +1,2 @@
+{{.Content.Greeting}} Admin,
+Security Response Automation


### PR DESCRIPTION
@tomscript,

As mentioned in #39 I include here html/template abstraction to be used on template.

```go
//Template: "Hello Admin, {{.Content}}"

fileName := "template.tmpl"
body := struct {
	Content string
}{
	Content: "body message",
}

//Use by template entity:
tmpl := NewTemplate(fileName)
res, err := tmpl.Render(body)

//Using by email entity:
email = NewEmail(service)
email.RenderTemplate("template.tmpl", body)
```

Just to organize I moved the common interface/response code from Email Client to client/email.go and extract external specific code to email_sendgrid.go, lmk if what you think.