### PR TITLE
simplify sha findings

### DIFF
--- a/cloudfunctions/close_bucket.go
+++ b/cloudfunctions/close_bucket.go
@@ -34,7 +34,7 @@ var (
 
 // CloseBucket will remove any public users from buckets found within the provided folders.
 func CloseBucket(ctx context.Context, m pubsub.Message, ent *entities.Entity) error {
-	finding, err := sha.NewStorageScanner(&m)
+	finding, err := sha.NewFinding(&m)
 	if err != nil {
 		return errors.Wrap(err, "failed to read finding")
 	}
@@ -53,9 +53,9 @@ func CloseBucket(ctx context.Context, m pubsub.Message, ent *entities.Entity) er
 	return nil
 }
 
-func remove(ctx context.Context, finding *sha.StorageScanner, log *entities.Logger, res *entities.Resource) func() error {
+func remove(ctx context.Context, finding *sha.Finding, log *entities.Logger, res *entities.Resource) func() error {
 	return func() error {
-		log.Info("removing public members from bucket %q in project %q.", finding.BucketName(), finding.ProjectID())
-		return res.RemoveMembersFromBucket(ctx, finding.BucketName(), publicUsers)
+		log.Info("removing public members from bucket %q in project %q.", finding.StorageScanner.BucketName(), finding.ProjectID())
+		return res.RemoveMembersFromBucket(ctx, finding.StorageScanner.BucketName(), publicUsers)
 	}
 }

--- a/entities/finding.go
+++ b/entities/finding.go
@@ -43,19 +43,13 @@ var (
 // easily we wrap in a method without error checking. To prevent accesor failures each finding will
 // implement a `validate` method that ensure all 'getter' method calls will succeed.
 
+type Interface interface {
+	Fields() interface{}
+	Validate() bool
+}
+
 // StackDriverLog struct fits StackDriver logs.
 type StackDriverLog struct {
 	InsertID string `json:"insertId"`
 	LogName  string `json:"logName"`
-}
-
-// badNetworkFinding contains any finding based off VPC flow logs.
-type badNetworkFinding struct {
-	JSONPayload struct {
-		Properties struct {
-			Location       string
-			SourceInstance string
-			IP             []string
-		}
-	}
 }

--- a/providers/sha/compute_instance_scanner.go
+++ b/providers/sha/compute_instance_scanner.go
@@ -16,45 +16,28 @@ package sha
 
 import (
 	"regexp"
-
-	"github.com/googlecloudplatform/threat-automation/entities"
-
-	"cloud.google.com/go/pubsub"
-	"github.com/pkg/errors"
 )
 
-// extractZone is a regex to extract the zone of the instance that is on the external uri.
-var extractZone = regexp.MustCompile(`/zones/(.+)/instances`)
+var (
+	// extractZone is a regex to extract the zone of the instance that is on the external uri.
+	extractZone = regexp.MustCompile(`/zones/(.+)/instances`)
 
-// extractInstance is a regex to extract the name of the instance that is on the external uri.
-var extractInstance = regexp.MustCompile(`/instances/(.+)`)
+	// extractInstance is a regex to extract the name of the instance that is on the external uri.
+	extractInstance = regexp.MustCompile(`/instances/(.+)`)
+)
 
-// ComputeInstanceScanner a Security Health Analytics finding from Compute Instance Scanner.
+// ComputeInstanceScanner represents a SHA Compute Istance Scanner finding.
 type ComputeInstanceScanner struct {
 	*Finding
+
+	fields *struct{}
 }
 
-// NewFirewallScanner creates a new FirewallScanner
-func NewComputeInstanceScanner(ps *pubsub.Message) (*ComputeInstanceScanner, error) {
-	f := ComputeInstanceScanner{}
+// Fields returns this finding's fields.
+func (f *ComputeInstanceScanner) Fields() interface{} { return &f.fields }
 
-	nf, err := NewFinding(ps)
-	if err != nil {
-		return nil, err
-	}
-
-	f.Finding = nf
-
-	if !f.validate() {
-		return nil, errors.Wrap(entities.ErrValueNotFound, "not a COMPUTE_INSTANCE_SCANNER Finding")
-	}
-
-	return &f, nil
-}
-
-func (f *ComputeInstanceScanner) validate() bool {
-	return f.ScannerName() == "COMPUTE_INSTANCE_SCANNER"
-}
+// Validate confirms if this finding's fields are correct.
+func (f *ComputeInstanceScanner) Validate() bool { return true }
 
 // Zone returns the zone of the instance.
 func (f *ComputeInstanceScanner) Zone() string {

--- a/providers/sha/iam_scanner.go
+++ b/providers/sha/iam_scanner.go
@@ -14,55 +14,25 @@ package sha
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import (
-	"encoding/json"
+// IamScanner represents a SHA IAM Scanner finding.
+type IamScanner struct {
+	*Finding
 
-	"cloud.google.com/go/pubsub"
-	"github.com/googlecloudplatform/threat-automation/entities"
-	"github.com/pkg/errors"
-)
-
-type iamScanner struct {
-	Finding struct {
-		Name             string
-		SourceProperties struct {
-			OffendingIamRoles string
+	fields struct {
+		Finding struct {
+			Name             string
+			SourceProperties struct {
+				OffendingIamRoles string
+			}
 		}
 	}
 }
 
-// IamScanner is an abstraction around SHA's IAM Scanner finding.
-type IamScanner struct {
-	// Fields found in every SHA finding not specific to this finding.
-	*Finding
-	// Fields specific to this finding.
-	fields iamScanner
-}
+// Fields returns this finding's fields.
+func (f *IamScanner) Fields() interface{} { return &f.fields }
 
-// NewIamScanner reads a pubsub message and creates a new finding.
-func NewIamScanner(ps *pubsub.Message) (*IamScanner, error) {
-	f := IamScanner{}
-
-	nf, err := NewFinding(ps)
-	if err != nil {
-		return nil, err
-	}
-
-	f.Finding = nf
-
-	if err := json.Unmarshal(ps.Data, &f.fields); err != nil {
-		return nil, err
-	}
-
-	if !f.validate() {
-		return nil, errors.Wrap(entities.ErrValueNotFound, "not a IAM_SCANNER Finding")
-	}
-	return &f, nil
-}
-
-func (f *IamScanner) validate() bool {
-	return f.ScannerName() == "IAM_SCANNER"
-}
+// Validate confirms if this finding's fields are correct.
+func (f *IamScanner) Validate() bool { return true }
 
 // OffendingIamRoles returns the offending IAM roles.
 func (f *IamScanner) OffendingIamRoles() string {

--- a/providers/sha/storage_scanner.go
+++ b/providers/sha/storage_scanner.go
@@ -16,10 +16,6 @@ package sha
 
 import (
 	"strings"
-
-	"cloud.google.com/go/pubsub"
-	"github.com/googlecloudplatform/threat-automation/entities"
-	"github.com/pkg/errors"
 )
 
 // resourcePrefix the prefix of the full name of a bucket
@@ -28,30 +24,16 @@ const resourcePrefix = "//storage.googleapis.com/"
 
 // StorageScanner is an abstraction around SHA's IAM Scanner finding.
 type StorageScanner struct {
-	// Fields found in every SHA finding not specific to this finding.
 	*Finding
+	
+	fields struct{}
 }
 
-// NewStorageScanner reads a pubsub message and creates a new finding.
-func NewStorageScanner(ps *pubsub.Message) (*StorageScanner, error) {
-	f := StorageScanner{}
+// Fields returns this finding's fields.
+func (f *StorageScanner) Fields() interface{} { return &f.fields }
 
-	nf, err := NewFinding(ps)
-	if err != nil {
-		return nil, err
-	}
-
-	f.Finding = nf
-
-	if !f.validate() {
-		return nil, errors.Wrap(entities.ErrValueNotFound, "not a STORAGE_SCANNER Finding")
-	}
-	return &f, nil
-}
-
-func (f *StorageScanner) validate() bool {
-	return f.ScannerName() == "STORAGE_SCANNER"
-}
+// Validate confirms if this finding's fields are correct.
+func (f *StorageScanner) Validate() bool { return f.ScannerName() == "STORAGE_SCANNER" }
 
 // BucketName returns name of the bucket. Resource assumed valid due to prior validate call.
 func (f *StorageScanner) BucketName() string {


### PR DESCRIPTION
@daniel-cit can you PTAL? i wanted to attempt and simplify how we deserialize findings starting with SHA. the problem is every finding type requires its own deserialization method which is not cool. at the same time its a bit difficult to code something generically without generics.

instead of having every single SHA finding do the work of reading and creating itself i instead moved the logic within `sha/findings.go`. there we have a switch statement that hands the various types so at least its in one place.

we then only require that each finding type export `Fields()` so we can get their struct to populate and a `Validate()` call that I left unimplemented. few things;

- i didnt have a chance to finish the PR completely so consider this request for feedback more than a thorough review. 
- i definitely went a bit heavy on the simplification in some cases. for example the validate calls now just return a bool. we lose the context of which field is missing but i feel that'll be rare since internally we deal with protos. it either passes or not. it just kept the methods simpler so i went with it.

Thanks!