### PR TITLE
remove eol from test template file

### DIFF
--- a/entities/email_test.go
+++ b/entities/email_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestParseTemplateEmail(t *testing.T) {
 
-	var sampleTemplate = "%s Admin,\nSecurity Response Automation"
+	var sampleTemplate = "%s Admin, Security Response Automation"
 
 	type sampleContent struct {
 		Greeting string

--- a/templates/testdata/sample.tmpl
+++ b/templates/testdata/sample.tmpl
@@ -1,2 +1,1 @@
-{{.Content.Greeting}} Admin,
-Security Response Automation
+{{.Content.Greeting}} Admin, Security Response Automation


### PR DESCRIPTION
Issue #76

Remove end of line to avoid broke tests on Windows OS environment.