### PR TITLE
Add pre-commit config for the project.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+# https://pre-commit.com/
+# A framework for managing and maintaining multi-language pre-commit hooks.
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.4.0
+  hooks:
+    - id: check-added-large-files
+    - id: check-case-conflict
+    - id: check-json
+    - id: check-merge-conflict
+    - id: check-toml
+    - id: check-xml
+    - id: check-yaml
+    - id: detect-private-key
+    - id: mixed-line-ending
+    - id: end-of-file-fixer
+      exclude: 'templates/.*'
+    - id: trailing-whitespace
+      exclude: 'templates/.*'
+- repo: git://github.com/dnephin/pre-commit-golang
+  rev: master
+  hooks:
+    - id: go-fmt
+    - id: go-vet
+      stages: [push]
+    - id: go-lint
+    - id: go-imports
+      exclude: '.*\.pb\.go'
+    - id: go-cyclo
+      args: [-over=10]
+      exclude: '.*_test\.go'
+    - id: validate-toml
+    - id: no-go-testing
+    - id: golangci-lint
+    - id: go-unit-tests
+    - id: go-build
+- repo: git://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.19.0
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_docs


### PR DESCRIPTION
Adding pre-commit so everyone could follow the same standards, and avoid some code reviews that can be automated.

Check https://pre-commit.com/#install and https://pre-commit.com/#usage.