### PR TITLE
[router] Add browser role to service account

### DIFF
--- a/cloudfunctions/router/main.tf
+++ b/cloudfunctions/router/main.tf
@@ -34,3 +34,11 @@ resource "google_project_iam_member" "router-pubsub-writer" {
   project = var.setup.automation-project
   member  = "serviceAccount:${var.setup.automation-service-account}"
 }
+
+# Required to retrieve ancestry for projects within this folder.
+resource "google_folder_iam_member" "roles-browser" {
+  count  = length(var.folder-ids)
+  folder = "folders/${var.folder-ids[count.index]}"
+  role   = "roles/browser"
+  member = "serviceAccount:${var.setup.automation-service-account}"
+}

--- a/cloudfunctions/router/variables.tf
+++ b/cloudfunctions/router/variables.tf
@@ -1,1 +1,6 @@
 variable "setup" {}
+
+variable "folder-ids" {
+  type        = list(string)
+  description = "Folder IDs to grant the necessary permissions for this Cloud Function execution."
+}

--- a/main.tf
+++ b/main.tf
@@ -34,8 +34,9 @@ module "google-setup" {
 }
 
 module "router" {
-  source = "./cloudfunctions/router/"
-  setup  = module.google-setup
+  source     = "./cloudfunctions/router/"
+  setup      = module.google-setup
+  folder-ids = var.folder-ids
 }
 
 module "close_public_bucket" {


### PR DESCRIPTION
Add Browser role to the service account for validation of project ancestry  in router CF