### PR TITLE
Bugfix: check error before checking value.

### DIFF
--- a/cloudfunctions/router/router.go
+++ b/cloudfunctions/router/router.go
@@ -487,11 +487,11 @@ func Execute(ctx context.Context, values *Values, services *Services) error {
 
 func publish(ctx context.Context, services *Services, action, topic, projectID string, target, exclude []string, values interface{}) error {
 	ok, err := services.Resource.CheckMatches(ctx, projectID, target, exclude)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if project %q is within the target or is excluded", projectID)
+	}
 	if !ok {
 		return fmt.Errorf("project %q is not within the target or is excluded", projectID)
-	}
-	if err != nil {
-		return errors.Wrapf(err, "failed to run %q", action)
 	}
 	b, err := json.Marshal(&values)
 	if err != nil {


### PR DESCRIPTION
It is necessary to check if err != nil before using the value of 
```
ok, err := services.Resource.CheckMatches(ctx, projectID, target, exclude)
```
Otherwise it will fail silently if we got an Error 403.

Before bugfix:

```
D 2019-12-31T00:45:07.035152829Z Router 441191963376998 Function execution started Router 441191963376998 
A 2019-12-31T00:45:07.533Z Router 441191963376998 2019/12/31 00:45:07 failed to publish: "project \"voltaic-flag-2602150\" is not within the target or is excluded" Router 441191963376998 
D 2019-12-31T00:45:07.537736422Z Router 441191963376998 Function execution took 504 ms, finished with status: 'ok' Router 441191963376998 
```

After bugfix:

```
D 2019-12-31T01:09:56.144335281Z Router 830332960495549 Function execution started Router 830332960495549 
A 2019-12-31T01:09:56.244Z Router 830332960495549 2019/12/31 01:09:56 failed to publish: "failed to check if project \"voltaic-flag-2602150\" is within the target or is excluded: failed to get project ancestry path: googleapi: Error 403: The caller does not have permission, forbidden" Router 830332960495549 
D 2019-12-31T01:09:56.244719118Z Router 830332960495549 Function execution took 101 ms, finished with status: 'ok' Router 830332960495549 
```


 