### PR TITLE
fix typos and add config.yaml to error message

### DIFF
--- a/cloudfunctions/router/router.go
+++ b/cloudfunctions/router/router.go
@@ -123,7 +123,7 @@ func Config() (*Configuration, error) {
 		return nil, err
 	}
 	if err := yaml.Unmarshal(b, &c); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to unmarshal config.yaml")
 	}
 	return &c, nil
 }
@@ -510,7 +510,7 @@ func publish(ctx context.Context, services *Services, action, topic, projectID s
 	}
 	b, err := json.Marshal(&values)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal when runing %q", action)
+		return errors.Wrapf(err, "failed to marshal when running %q", action)
 	}
 	if _, err := services.PubSub.Publish(ctx, topic, &pubsub.Message{
 		Data: b,


### PR DESCRIPTION
Fix two typos and add config.yaml to error message.

Before:

```
D 2020-01-02T14:50:08.473054748Z Router 837923264596131 Function execution started Router 837923264596131 
D 2020-01-02T14:50:08.604505590Z Router 837923264596131 Function execution took 132 ms, finished with status: 'error' Router 837923264596131 
E 2020-01-02T14:50:09.663Z Router 837923264596131 Function error: yaml: line 126: could not find expected ':'
```

After:

```
D 2020-01-02T21:57:42.391997002Z Router 838488507192516 Function execution started Router 838488507192516 
D 2020-01-02T21:57:42.520128440Z Router 838488507192516 Function execution took 129 ms, finished with status: 'error' Router 838488507192516 
E 2020-01-02T21:57:43.523Z Router 838488507192516 Function error: failed to unmarshal config.yaml: yaml: line 126: could not find expected ':'
```