### PR TITLE
Removes unnecessary roles from scc notifications sa

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,16 +134,6 @@ go run ./local/cli/main.go \
 // event_type:FINDING pubsub_topic:"projects/ae-threat-detection/topics/cscc-notifications-topic"
 // service_account:"service-459837319394@gcp-sa-scc-notification.iam.gserviceaccount.com"
 // streaming_config:<filter:"state = \"ACTIVE\"" >
-//
-// Make sure to replace `$SERVICE_ACCOUNT_FROM_ABOVE` with the generated service account.
-
-gcloud beta pubsub topics add-iam-policy-binding projects/$PROJECT_ID/topics/$TOPIC_ID \
---member="serviceAccount:$SERVICE_ACCOUNT_FROM_ABOVE" \
---role="roles/pubsub.publisher"
-
-gcloud pubsub topics add-iam-policy-binding projects/$PROJECT_ID/topics/threat-findings \
---member="serviceAccount:$SERVICE_ACCOUNT_FROM_ABOVE" \
---role="roles/securitycenter.notificationServiceAgent"
 
 gcloud organizations remove-iam-policy-binding $ORGANIZATION_ID \
 --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \


### PR DESCRIPTION
In the section `Set up Security Command Center Notifications` in README, after running the script to create the SCC Notifications there are two commands to add roles to a service account:

```
gcloud beta pubsub topics add-iam-policy-binding projects/$PROJECT_ID/topics/$TOPIC_ID \
--member="serviceAccount:$SERVICE_ACCOUNT_FROM_ABOVE" \
--role="roles/pubsub.publisher"


gcloud pubsub topics add-iam-policy-binding projects/$PROJECT_ID/topics/threat-findings \
--member="serviceAccount:$SERVICE_ACCOUNT_FROM_ABOVE" \
--role="roles/securitycenter.notificationServiceAgent"
```
After some tests creating a project and following the steps to create the SCC Notifications, it seems that adding both roles is unnecessary. After the step to grant the role `roles/pubsub.admin` to the service account utilized in the script `./local/cli/main.go`, the generated service account of the SCC Notifications receives the role `roles/securitycenter.notificationServiceAgent`. Since it is a role that has the same permissions that the role `roles/pubsub.publisher`, there is no need to add those commands in the README.