### PR TITLE
Use official documentation steps to create SCC Notifications in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,7 @@ gcloud alpha scc notifications create sra-notification \
 --description "Notifications for active findings" \
 --pubsub-topic projects/$PROJECT_ID/topics/$TOPIC_ID \
 --event-type FINDING \
---filter "state=\"ACTIVE"\" \
---impersonate-service-account $SERVICE_ACCOUNT_EMAIL
+--filter "state=\"ACTIVE"\"
 
 gcloud organizations remove-iam-policy-binding $ORGANIZATION_ID \
 --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \


### PR DESCRIPTION
- Replaces the go cli command with the gcloud command to install SCC Notifications.