### PR TITLE
update gcloud commands instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ export SERVICE_ACCOUNT_EMAIL=automation-service-account@$PROJECT_ID.iam.gservice
 ORGANIZATION_ID=<YOUR_ORGANIZATION_ID> \
 TOPIC_ID=threat-findings
 
-gcloud beta organizations add-iam-policy-binding \
-$ORGANIZATION_ID \
+gcloud organizations add-iam-policy-binding $ORGANIZATION_ID \
 --member="serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
 --role='roles/securitycenter.notificationConfigEditor'
 
@@ -125,7 +124,6 @@ gcloud alpha scc notifications create sra-notification \
 --organization "$ORGANIZATION_ID" \
 --description "Notifications for active findings" \
 --pubsub-topic projects/$PROJECT_ID/topics/$TOPIC_ID \
---event-type FINDING \
 --filter "state=\"ACTIVE"\"
 
 gcloud organizations remove-iam-policy-binding $ORGANIZATION_ID \


### PR DESCRIPTION
The command `gcloud alpha scc notifications create` has lost one one its parameters and is falling on the creation of the notification:

>gcloud alpha scc notifications create sra-notification \
> --organization "$ORGANIZATION_ID" \
> --description "Notifications for active findings" \
> --pubsub-topic projects/$PROJECT_ID/topics/$TOPIC_ID \
> --event-type FINDING \
> --filter "state=\"ACTIVE"\"

`ERROR: (gcloud.alpha.scc.notifications.create) unrecognized arguments:
 --event-type FINDING
 To search the help text of gcloud commands, run:
 gcloud help -- SEARCH_TERMS`

Current documentation:
https://cloud.google.com/sdk/gcloud/reference/alpha/scc/notifications/create

`gcloud alpha scc notifications create NOTIFICATION_CONFIG_ID --pubsub-topic=PUBSUB_TOPIC [--description=DESCRIPTION] [--filter=FILTER] [--organization=ORGANIZATION] [GCLOUD_WIDE_FLAG …]`

Also,  

`gcloud beta organizations add-iam-policy-binding ` 

has been replaced with the GA version

`gcloud organizations add-iam-policy-binding `