### PR TITLE
Use case insensitive equals in IAM revoke.

### DIFF
--- a/cloudfunctions/iam/revoke/revoke_test.go
+++ b/cloudfunctions/iam/revoke/revoke_test.go
@@ -68,7 +68,7 @@ func TestIAMRevoke(t *testing.T) {
 			folderIDs:       []string{"folderID"},
 			projectIDs:      []string{},
 			externalMembers: []string{"user:tom@gmail.com"},
-			initialMembers:  []string{"user:test@test.com", "user:tom@gmail.com", "user:existing@gmail.com"},
+			initialMembers:  []string{"user:test@test.com", "user:Tom@gmail.com", "user:existing@gmail.com"},
 			allowed:         []string{},
 			expectedMembers: []string{"user:test@test.com", "user:existing@gmail.com"},
 			ancestry:        services.CreateAncestors([]string{"project/projectID", "folder/folderID", "organization/organizationID"}),

--- a/services/resource.go
+++ b/services/resource.go
@@ -205,7 +205,7 @@ func (r *Resource) removeUsersFromPolicy(policy *crm.Policy, users []string) *cr
 			isUser := strings.HasPrefix(member, "user:")
 			found := false
 			for _, user := range users {
-				if user == member {
+				if strings.EqualFold(user, member) {
 					found = true
 					break
 				}


### PR DESCRIPTION
When removing an external user from the project IAM policy it is necessary to use a case insensitive equals.

for example, added external user `jane.doe@example.com` would be `Jane.Doe@example.com` in the project policy, which would cause the code not to remove her from the policy.