### PR TITLE
Add missing remediation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ generate:
 	go generate ./...
 
 tools:
-	go get github.com/securego/gosec/v2/cmd/gosec
-	go get github.com/fzipp/gocyclo/cmd/gocyclo
-	go get golang.org/x/lint/golint
+	go install github.com/securego/gosec/v2/cmd/gosec
+	go install github.com/fzipp/gocyclo/cmd/gocyclo
+	go install golang.org/x/lint/golint
 
 fmt:
 	go fmt ./...

--- a/cloudfunctions/router/router_test.go
+++ b/cloudfunctions/router/router_test.go
@@ -369,9 +369,19 @@ func TestRemediated(t *testing.T) {
 		{name: "audit_logging_disabled", finding: "audit_logging_disabled-remediated.json"},
 		{name: "bad_ip_scc", finding: "bad_ip_scc-remediated.json"},
 		{name: "bucket_policy_only_disabled", finding: "bucket_policy_only_disabled-remediated.json"},
+		{name: "iam_anomalous_grant", finding: "iam_anomalous_grant-remediated.json"},
 		{name: "non_org_iam_member", finding: "non_org_iam_member-remediated.json"},
+		{name: "open_firewall", finding: "open_firewall-remediated.json"},
+		{name: "open_rdp_port", finding: "open_rdp_port-remediated.json"},
+		{name: "open_ssh_port", finding: "open_ssh_port-remediated.json"},
 		{name: "public_bucket_acl", finding: "public_bucket_acl-remediated.json"},
 		{name: "public_dataset", finding: "public_dataset-remediated.json"},
+		{name: "public_ip_address", finding: "public_ip_address-remediated.json"},
+		{name: "public_sql_instance", finding: "public_sql_instance-remediated.json"},
+		{name: "sql_no_root_password", finding: "sql_no_root_password-remediated.json"},
+		{name: "ssh_brute_force", finding: "ssh_brute_force-remediated.json"},
+		{name: "ssl_not_enforced", finding: "ssl_not_enforced-remediated.json"},
+		{name: "web_ui_enabled", finding: "web_ui_enabled-remediated.json"},
 	} {
 		finding := testData(t, tt.finding)
 

--- a/cloudfunctions/router/router_test.go
+++ b/cloudfunctions/router/router_test.go
@@ -50,161 +50,6 @@ func testData(t *testing.T, filename string) []byte {
 }
 
 func TestRouter(t *testing.T) {
-	const (
-		validBadIP = `{
-			"jsonPayload": {
-				"properties": {
-					"instanceDetails": "/projects/test-project/zones/zone-name/instances/source-instance-name",
-					"network": {
-						"project": "test-project"
-					}
-				},
-				"detectionCategory": {
-					"ruleName": "bad_ip"
-				}
-			},
-			"logName": "projects/test-project/logs/threatdetection.googleapis.com` + "%%2F" + `detection"
-		}`
-		validBadIPSCC = `{
-			"notificationConfigName": "organizations/0000000000000/notificationConfigs/noticonf-active-001-id",
-			"finding": {
-				"name": "organizations/0000000000000/sources/0000000000000000000/findings/6a30ce604c11417995b1fa260753f3b5",
-				"parent": "organizations/0000000000000/sources/0000000000000000000",
-				"resourceName": "//cloudresourcemanager.googleapis.com/projects/000000000000",
-				"state": "ACTIVE",
-				"category": "C2: Bad IP",
-				"externalUri": "https://console.cloud.google.com/home?project=test-project-15511551515",
-				"sourceProperties": {
-					"detectionCategory": {
-						"ruleName": "bad_ip"
-					},
-					"properties": {
-						"instanceDetails": "/projects/test-project-15511551515/zones/us-central1-a/instances/bad-ip-caller",
-							"network": {
-   								"project": "test-project-15511551515"
-							}
-					}
-				},
-				"securityMarks": {
-					"name": "organizations/0000000000000/sources/0000000000000000000/findings/6a30ce604c11417995b1fa260753f3b5/securityMarks",
-					"marks": {
-						"sra-remediated-event-time": "2019-11-22T18:34:00.000Z"
-					}
-				},
-				"eventTime": "2019-11-22T18:34:36.153Z",
-				"createTime": "2019-11-22T18:34:36.688Z"
-			}
-		}`
-		validPublicBucket = `{
-			"notificationConfigName": "organizations/154584661726/notificationConfigs/sampleConfigId",
-			"finding": {
-				"name": "organizations/154584661726/sources/2673592633662526977/findings/782e52631d61da6117a3772137c270d8",
-				"parent": "organizations/154584661726/sources/2673592633662526977",
-				"resourceName": "//storage.googleapis.com/this-is-public-on-purpose",
-				"state": "ACTIVE",
-				"category": "PUBLIC_BUCKET_ACL",
-				"externalUri": "https://console.cloud.google.com/storage/browser/this-is-public-on-purpose",
-				"sourceProperties": {
-					"ReactivationCount": 0.0,
-					"ExceptionInstructions": "Add the security mark \"allow_public_bucket_acl\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
-					"SeverityLevel": "High",
-					"Recommendation": "Go to https://console.cloud.google.com/storage/browser/this-is-public-on-purpose, click on the Permissions tab, and remove \"allUsers\" and \"allAuthenticatedUsers\" from the bucket's members.",
-					"ProjectId": "test-project",
-					"AssetCreationTime": "2019-09-19T20:08:29.102Z",
-					"ScannerName": "STORAGE_SCANNER",
-					"ScanRunId": "2019-09-23T10:20:27.204-07:00",
-					"Explanation": "This bucket is public and can be accessed by anyone on the Internet. \"allUsers\" represents anyone on the Internet, and \"allAuthenticatedUsers\" represents anyone who is authenticated with a Google account; neither is constrained to users within your organization."
-				},
-				"securityMarks": {
-					"name": "organizations/154584661726/sources/2673592633662526977/findings/782e52631d61da6117a3772137c270d8/securityMarks",
-					"marks": {
-						"babab": "3"
-					}
-				},
-				"eventTime": "2019-09-23T17:20:27.204Z",
-				"createTime": "2019-09-23T17:20:27.934Z"
-			}
-		}`
-		validPublicDataset = `{
-			"notificationConfigName": "organizations/154584661726/notificationConfigs/sampleConfigId",
-			"finding": {
-				"name": "organizations/154584661726/sources/7086426792249889955/findings/8682cf07ec50f921172082270bdd96e7",
-				"parent": "organizations/154584661726/sources/7086426792249889955",
-				"resourceName": "//bigquery.googleapis.com/projects/test-project/datasets/public_dataset123",
-				"state": "ACTIVE",
-				"category": "PUBLIC_DATASET",
-				"externalUri": "https://console.cloud.google.com/bigquery?project=test-project&folder&organizationId=154584661726&p=test-project&d=public_dataset123&page=dataset",
-				"sourceProperties": {
-				  "ReactivationCount": 0,
-				  "ExceptionInstructions": "Add the security mark \"allow_public_dataset\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
-				  "SeverityLevel": "High",
-				  "Recommendation": "Go to https://console.cloud.google.com/bigquery?project=test-project&folder&organizationId=154584661726&p=test-project&d=public_dataset123&page=dataset, click \"SHARE DATASET\", search members for \"allUsers\" and \"allAuthenticatedUsers\",  and remove access for those members.",
-				  "ProjectId": "test-project",
-				  "AssetCreationTime": "2019-10-02T18:28:42.182Z",
-				  "ScannerName": "DATASET_SCANNER",
-				  "ScanRunId": "2019-10-03T11:40:22.538-07:00",
-				  "Explanation": "This dataset is public and can be accessed by anyone on the Internet. \"allUsers\" represents anyone on the Internet, and \"allAuthenticatedUsers\" represents anyone who is authenticated with a Google account; neither is constrained to users within your organization."
-				},
-				"securityMarks": {
-				  "name": "organizations/154584661726/sources/7086426792249889955/findings/8682cf07ec50f921172082270bdd96e7/securityMarks"
-				},
-				"eventTime": "2019-10-03T18:40:22.538Z",
-				"createTime": "2019-10-03T18:40:23.445Z"
-			}
-		}`
-		validAuditLogDisabled = `{
-		"finding": {
-			"name": "organizations/154584661726/sources/1986930501971458034/findings/1c35bd4b4f6d7145e441f2965c32f074",
-			"parent": "organizations/154584661726/sources/1986930501971458034",
-			"resourceName": "//cloudresourcemanager.googleapis.com/projects/108906606255",
-			"state": "ACTIVE",
-			"category": "AUDIT_LOGGING_DISABLED",
-			"externalUri": "https://console.cloud.google.com/iam-admin/audit/allservices?project=test-project",
-			"sourceProperties": {
-				"ReactivationCount": 0,
-				"ExceptionInstructions": "Add the security mark \"allow_audit_logging_disabled\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
-				"SeverityLevel": "Low",
-				"Recommendation": "Go to https://console.cloud.google.com/iam-admin/audit/allservices?project=test-project and under \"LOG TYPE\" select \"Admin read\", \"Data read\", and \"Data write\", and then click \"SAVE\". Make sure there are no exempted users configured.",
-				"ProjectId": "test-project",
-				"AssetCreationTime": "2019-10-22T15:13:39.305Z",
-				"ScannerName": "LOGGING_SCANNER",
-				"ScanRunId": "2019-10-22T14:01:08.832-07:00",
-				"Explanation": "You should enable Cloud Audit Logging for all services, to track all Admin activities including read and write access to user data."
-			},
-			"securityMarks": {
-				"name": "organizations/154584661726/sources/1986930501971458034/findings/1c35bd4b4f6d7145e441f2965c32f074/securityMarks"
-			},
-			"eventTime": "2019-10-22T21:01:08.832Z",
-			"createTime": "2019-10-22T21:01:39.098Z"
-		   }
-		}`
-		validNonOrgMembers = `{
-		"finding": {
-			"name": "organizations/1050000000008/sources/1986930501000008034/findings/047db1bc23a4b1fb00cbaa79b468945a",
-			"parent": "organizations/1050000000008/sources/1986930501000008034",
-			"resourceName": "//cloudresourcemanager.googleapis.com/projects/72300000536",
-			"state": "ACTIVE",
-			"category": "NON_ORG_IAM_MEMBER",
-			"externalUri": "https://console.cloud.google.com/iam-admin/iam?project=test-project",
-			"sourceProperties": {
-				"ReactivationCount": 0,
-				"ExceptionInstructions": "Add the security mark \"allow_non_org_iam_member\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
-				"SeverityLevel": "High",
-				"Recommendation": "Go to https://console.cloud.google.com/iam-admin/iam?project=test-project and remove entries for users which are not in your organization (e.g. gmail.com addresses).",
-				"ProjectId": "test-project",
-				"AssetCreationTime": "2019-02-26T15:41:40.726Z",
-				"ScannerName": "IAM_SCANNER",
-				"ScanRunId": "2019-10-18T08:30:22.082-07:00",
-				"Explanation": "A user outside of your organization has IAM permissions on a project or organization."
-			},
-			"securityMarks": {
-				"name": "organizations/1050000000008/sources/1986930501000008034/findings/047db1bc23a4b1fb00cbaa79b468945a/securityMarks"
-			},
-			"eventTime": "2019-10-18T15:30:22.082Z",
-			"createTime": "2019-10-18T15:31:58.487Z"
-           }
-		}`
-	)
 	conf := &Configuration{}
 	// BadIP findings should map to "gce_create_disk_snapshot".
 	conf.Spec.Parameters.ETD.BadIP = []Automation{
@@ -280,33 +125,33 @@ func TestRouter(t *testing.T) {
 	}{
 		{
 			name:    "audit_logging_disabled",
-			finding: []byte(validAuditLogDisabled),
+			finding: testData(t, "audit_logging_disabled.json"),
 			mapTo:   enableAuditLog,
 		},
 		{
 			name:    "bad_ip",
-			finding: []byte(validBadIP),
+			finding: testData(t, "bad_ip.json"),
 			nonSCC:  true,
 			mapTo:   createSnapshot,
 		},
 		{
 			name:    "bad_ip_scc",
-			finding: []byte(validBadIPSCC),
+			finding: testData(t, "bad_ip_scc.json"),
 			mapTo:   sccCreateSnapshot,
 		},
 		{
 			name:    "non_org_members",
-			finding: []byte(validNonOrgMembers),
+			finding: testData(t, "non_org_iam_member.json"),
 			mapTo:   removeNonOrgMembers,
 		},
 		{
 			name:    "public_bucket_acl",
-			finding: []byte(validPublicBucket),
+			finding: testData(t, "public_bucket_acl.json"),
 			mapTo:   closeBucket,
 		},
 		{
 			name:    "public_dataset",
-			finding: []byte(validPublicDataset),
+			finding: testData(t, "public_dataset.json"),
 			mapTo:   closePublicDataset,
 		},
 	} {

--- a/cloudfunctions/router/testdata/audit_logging_disabled-remediated.json
+++ b/cloudfunctions/router/testdata/audit_logging_disabled-remediated.json
@@ -1,0 +1,31 @@
+{
+  "finding": {
+    "name": "organizations/154584661726/sources/1986930501971458034/findings/1c35bd4b4f6d7145e441f2965c32f074",
+    "parent": "organizations/154584661726/sources/1986930501971458034",
+    "resourceName": "//cloudresourcemanager.googleapis.com/projects/108906606255",
+    "state": "ACTIVE",
+    "category": "AUDIT_LOGGING_DISABLED",
+    "externalUri": "https://console.cloud.google.com/iam-admin/audit/allservices?project=test-project",
+    "sourceProperties": {
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_audit_logging_disabled\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "SeverityLevel": "Low",
+      "Recommendation": "Go to https://console.cloud.google.com/iam-admin/audit/allservices?project=test-project and under \"LOG TYPE\" select \"Admin read\", \"Data read\", and \"Data write\", and then click \"SAVE\". Make sure there are no exempted users configured.",
+      "ProjectId": "test-project",
+      "AssetCreationTime": "2019-10-22T15:13:39.305Z",
+      "ScannerName": "LOGGING_SCANNER",
+      "ScanRunId": "2019-10-22T14:01:08.832-07:00",
+      "Explanation": "You should enable Cloud Audit Logging for all services, to track all Admin activities including read and write access to user data."
+    },
+    "securityMarks": {
+      "name": "organizations/154584661726/sources/1986930501971458034/findings/1c35bd4b4f6d7145e441f2965c32f074/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2019-10-22T21:01:08.832Z"
+      }
+    },
+    "eventTime": "2019-10-22T21:01:08.832Z",
+    "createTime": "2019-10-22T21:01:39.098Z",
+    "assetId": "organizations/154584661726/assets/11190834741917282179",
+    "assetDisplayName": "test-project"
+  }
+}

--- a/cloudfunctions/router/testdata/audit_logging_disabled.json
+++ b/cloudfunctions/router/testdata/audit_logging_disabled.json
@@ -1,0 +1,26 @@
+{
+  "finding": {
+    "name": "organizations/154584661726/sources/1986930501971458034/findings/1c35bd4b4f6d7145e441f2965c32f074",
+    "parent": "organizations/154584661726/sources/1986930501971458034",
+    "resourceName": "//cloudresourcemanager.googleapis.com/projects/108906606255",
+    "state": "ACTIVE",
+    "category": "AUDIT_LOGGING_DISABLED",
+    "externalUri": "https://console.cloud.google.com/iam-admin/audit/allservices?project=test-project",
+    "sourceProperties": {
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_audit_logging_disabled\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "SeverityLevel": "Low",
+      "Recommendation": "Go to https://console.cloud.google.com/iam-admin/audit/allservices?project=test-project and under \"LOG TYPE\" select \"Admin read\", \"Data read\", and \"Data write\", and then click \"SAVE\". Make sure there are no exempted users configured.",
+      "ProjectId": "test-project",
+      "AssetCreationTime": "2019-10-22T15:13:39.305Z",
+      "ScannerName": "LOGGING_SCANNER",
+      "ScanRunId": "2019-10-22T14:01:08.832-07:00",
+      "Explanation": "You should enable Cloud Audit Logging for all services, to track all Admin activities including read and write access to user data."
+    },
+    "securityMarks": {
+      "name": "organizations/154584661726/sources/1986930501971458034/findings/1c35bd4b4f6d7145e441f2965c32f074/securityMarks"
+    },
+    "eventTime": "2019-10-22T21:01:08.832Z",
+    "createTime": "2019-10-22T21:01:39.098Z"
+  }
+}

--- a/cloudfunctions/router/testdata/bad_ip.json
+++ b/cloudfunctions/router/testdata/bad_ip.json
@@ -1,0 +1,14 @@
+{
+  "jsonPayload": {
+    "properties": {
+      "instanceDetails": "/projects/test-project/zones/zone-name/instances/source-instance-name",
+      "network": {
+	"project": "test-project"
+      }
+    },
+    "detectionCategory": {
+      "ruleName": "bad_ip"
+    }
+  },
+  "logName": "projects/test-project/logs/threatdetection.googleapis.com%%2Fdetection"
+}

--- a/cloudfunctions/router/testdata/bad_ip_scc-remediated.json
+++ b/cloudfunctions/router/testdata/bad_ip_scc-remediated.json
@@ -1,0 +1,30 @@
+{
+  "notificationConfigName": "organizations/0000000000000/notificationConfigs/noticonf-active-001-id",
+  "finding": {
+    "name": "organizations/0000000000000/sources/0000000000000000000/findings/6a30ce604c11417995b1fa260753f3b5",
+    "parent": "organizations/0000000000000/sources/0000000000000000000",
+    "resourceName": "//cloudresourcemanager.googleapis.com/projects/000000000000",
+    "state": "ACTIVE",
+    "category": "C2: Bad IP",
+    "externalUri": "https://console.cloud.google.com/home?project=test-project-15511551515",
+    "sourceProperties": {
+      "detectionCategory": {
+	"ruleName": "bad_ip"
+      },
+      "properties": {
+	"instanceDetails": "/projects/test-project-15511551515/zones/us-central1-a/instances/bad-ip-caller",
+	"network": {
+	  "project": "test-project-15511551515"
+	}
+      }
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000000/sources/0000000000000000000/findings/6a30ce604c11417995b1fa260753f3b5/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2019-11-22T18:34:36.153Z"
+      }
+    },
+    "eventTime": "2019-11-22T18:34:36.153Z",
+    "createTime": "2019-11-22T18:34:36.688Z"
+  }
+}

--- a/cloudfunctions/router/testdata/bad_ip_scc.json
+++ b/cloudfunctions/router/testdata/bad_ip_scc.json
@@ -1,0 +1,30 @@
+{
+  "notificationConfigName": "organizations/0000000000000/notificationConfigs/noticonf-active-001-id",
+  "finding": {
+    "name": "organizations/0000000000000/sources/0000000000000000000/findings/6a30ce604c11417995b1fa260753f3b5",
+    "parent": "organizations/0000000000000/sources/0000000000000000000",
+    "resourceName": "//cloudresourcemanager.googleapis.com/projects/000000000000",
+    "state": "ACTIVE",
+    "category": "C2: Bad IP",
+    "externalUri": "https://console.cloud.google.com/home?project=test-project-15511551515",
+    "sourceProperties": {
+      "detectionCategory": {
+	"ruleName": "bad_ip"
+      },
+      "properties": {
+	"instanceDetails": "/projects/test-project-15511551515/zones/us-central1-a/instances/bad-ip-caller",
+	"network": {
+	  "project": "test-project-15511551515"
+	}
+      }
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000000/sources/0000000000000000000/findings/6a30ce604c11417995b1fa260753f3b5/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2019-11-22T18:34:00.000Z"
+      }
+    },
+    "eventTime": "2019-11-22T18:34:36.153Z",
+    "createTime": "2019-11-22T18:34:36.688Z"
+  }
+}

--- a/cloudfunctions/router/testdata/bucket_policy_only_disabled-remediated.json
+++ b/cloudfunctions/router/testdata/bucket_policy_only_disabled-remediated.json
@@ -1,0 +1,104 @@
+{
+  "notificationConfigName": "organizations/154584661726/notificationConfigs/sampleConfigId",
+  "finding": {
+    "name": "organizations/000000000000/sources/0000000000000000000/findings/2f8efe97cf7c854a95918b4b2255967f",
+    "parent": "organizations/000000000000/sources/0000000000000000000",
+    "resourceName": "//storage.googleapis.com/unique-test-bucket",
+    "state": "ACTIVE",
+    "category": "BUCKET_POLICY_ONLY_DISABLED",
+    "externalUri": "https://console.cloud.google.com/storage/browser/unique-test-bucket",
+    "sourceProperties": {
+      "Recommendation": "Go to https://console.cloud.google.com/storage/browser/unique-test-bucket, click the \"Configuration\" tab, in the row for \"Access control\", click the edit icon, select \"Uniform\" in the \"Edit Access Control\" dialog, then click \"Save\".",
+      "ExceptionInstructions": "Add the security mark \"allow_bucket_policy_only_disabled\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "The Bucket Policy Only feature simplifies bucket access control by disabling object-level permissions (ACLs). When enabled, only bucket-level Cloud IAM permissions grant access to the bucket and the objects it contains. Learn more at: https://cloud.google.com/storage/docs/bucket-policy-only",
+      "ScannerName": "STORAGE_SCANNER",
+      "ResourcePath": ["projects/unique-test/", "organizations/000000000000/"],
+      "compliance_standards": {
+	"cis": [{
+	  "version": "1.2",
+	  "ids": ["5.2"]
+	}]
+      },
+      "ReactivationCount": 0.0
+    },
+    "securityMarks": {
+      "name": "organizations/000000000000/sources/0000000000000000000/findings/2f8efe97cf7c854a95918b4b2255967f/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2022-04-08T23:15:23.219Z"
+      }
+    },
+    "eventTime": "2022-04-08T23:15:23.219Z",
+    "createTime": "2022-04-08T23:15:23.665Z",
+    "propertyDataTypes": {
+      "ResourcePath": {
+	"listValues": {
+	  "propertyDataTypes": [{
+	    "primitiveDataType": "STRING"
+	  }]
+	}
+      },
+      "ReactivationCount": {
+	"primitiveDataType": "NUMBER"
+      },
+      "Explanation": {
+	"primitiveDataType": "STRING"
+      },
+      "ScannerName": {
+	"primitiveDataType": "STRING"
+      },
+      "compliance_standards": {
+	"structValue": {
+	  "fields": {
+	    "cis": {
+	      "listValues": {
+		"propertyDataTypes": [{
+		  "structValue": {
+		    "fields": {
+		      "version": {
+			"primitiveDataType": "STRING"
+		      },
+		      "ids": {
+			"listValues": {
+			  "propertyDataTypes": [{
+			    "primitiveDataType": "STRING"
+			  }]
+			}
+		      }
+		    }
+		  }
+		}]
+	      }
+	    }
+	  }
+	}
+      },
+      "ExceptionInstructions": {
+	"primitiveDataType": "STRING"
+      },
+      "Recommendation": {
+	"primitiveDataType": "STRING"
+      }
+    },
+    "severity": "MEDIUM",
+    "workflowState": "NEW",
+    "canonicalName": "projects/1234567889/sources/0000000000000000000/findings/2f8efe97cf7c854a95918b4b2255967f",
+    "mute": "UNDEFINED",
+    "findingClass": "MISCONFIGURATION",
+    "compliances": [{
+      "standard": "cis",
+      "version": "1.2",
+      "ids": ["5.2"]
+    }],
+    "originalProviderId": "SECURITY_HEALTH_ADVISOR",
+    "description": "The Bucket Policy Only feature simplifies bucket access control by disabling object-level permissions (ACLs). When enabled, only bucket-level Cloud IAM permissions grant access to the bucket and the objects it contains. Learn more at: https://cloud.google.com/storage/docs/bucket-policy-only"
+  },
+  "resource": {
+    "name": "//storage.googleapis.com/unique-test-bucket",
+    "projectName": "//cloudresourcemanager.googleapis.com/projects/1234567889",
+    "projectDisplayName": "unique-test",
+    "parentName": "//cloudresourcemanager.googleapis.com/projects/1234567889",
+    "parentDisplayName": "unique-test",
+    "type": "google.cloud.storage.Bucket",
+    "displayName": "unique-test-bucket"
+  }
+}

--- a/cloudfunctions/router/testdata/iam_anomalous_grant-remediated.json
+++ b/cloudfunctions/router/testdata/iam_anomalous_grant-remediated.json
@@ -1,0 +1,74 @@
+{
+  "finding": {
+    "name": "organizations/0000000000/sources/0000000/findings/12345",
+    "parent": "organizations/0000000000/sources/0000000",
+    "resourceName": "//cloudresourcemanager.googleapis.com/projects/12345678",
+    "state": "ACTIVE",
+    "category": "Persistence: IAM Anomalous Grant",
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/12345/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "1970-01-01T00:00:00Z"
+      }
+    },
+    "sourceProperties": {
+      "evidence": [
+        {
+          "sourceLogId": {
+            "timestamp": {
+              "nanos": 0.0,
+              "seconds": "0"
+            },
+            "insertId": "3"
+          }
+        }
+      ],
+      "properties": {
+        "project_id": "test-project",
+        "principalEmail": "test-user@test-project.iam.gserviceaccount.com",
+        "bindingDeltas": [
+          {
+            "action": "ADD",
+            "role": "roles/owner",
+            "member": "user:test-user@gmail.com"
+          }
+        ],
+        "externalMembers": [
+          "user:test-user@gmail.com"
+        ]
+      },
+      "detectionPriority": "HIGH",
+      "sourceId": {
+        "projectNumber": "6789",
+        "customerOrganizationNumber": "12345"
+      },
+      "detectionCategory": {
+        "technique": "persistence",
+        "indicator": "audit_log",
+        "ruleName": "iam_anomalous_grant",
+        "subRuleName": "external_member_added_to_policy"
+      },
+      "affectedResources": [
+        {
+          "gcpResourceName": "//cloudresourcemanager.googleapis.com/projects/12345678"
+        }
+      ],
+      "contextUris": {
+        "cloudLoggingQueryUri": [
+          {
+            "displayName": "Cloud Logging Query Link",
+            "url": "https://console.cloud.google.com/logs/query;query=timestamp%3D%221970-01-01T00:00:00Z%22%0AinsertId%3D%223%22%0Aresource.labels.project_id%3D%22%22?project="
+          }
+        ],
+        "relatedFindingUri": {
+          "displayName": "Related Anomalous Grant Findings",
+          "url": "https://console.cloud.google.com/security/command-center/findings?organizationId=12345&pageState=(%22cscc-inventory%22:(%22f%22:%22%255B%257B_22k_22_3A_22sourceProperties.detectionCategory.ruleName_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22iam_anomalous_grant_5C_22_22%257D_2C%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22%2528sourceProperties.properties.sensitiveRoleGrant.principalEmail_3A_5C_5C_5C_22_5C_5C_5C_22%2529_5C_22_22%257D%255D%22))"
+        }
+      }
+    },
+    "severity": "HIGH",
+    "findingClass": "THREAT",
+    "eventTime": "1970-01-01T00:00:00Z",
+    "createTime": "1970-01-01T00:00:00Z"
+  }
+}

--- a/cloudfunctions/router/testdata/non_org_iam_member-remediated.json
+++ b/cloudfunctions/router/testdata/non_org_iam_member-remediated.json
@@ -1,0 +1,29 @@
+{
+  "finding": {
+    "name": "organizations/1050000000008/sources/1986930501000008034/findings/047db1bc23a4b1fb00cbaa79b468945a",
+    "parent": "organizations/1050000000008/sources/1986930501000008034",
+    "resourceName": "//cloudresourcemanager.googleapis.com/projects/72300000536",
+    "state": "ACTIVE",
+    "category": "NON_ORG_IAM_MEMBER",
+    "externalUri": "https://console.cloud.google.com/iam-admin/iam?project=test-project",
+    "sourceProperties": {
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_non_org_iam_member\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "SeverityLevel": "High",
+      "Recommendation": "Go to https://console.cloud.google.com/iam-admin/iam?project=test-project and remove entries for users which are not in your organization (e.g. gmail.com addresses).",
+      "ProjectId": "test-project",
+      "AssetCreationTime": "2019-02-26T15:41:40.726Z",
+      "ScannerName": "IAM_SCANNER",
+      "ScanRunId": "2019-10-18T08:30:22.082-07:00",
+      "Explanation": "A user outside of your organization has IAM permissions on a project or organization."
+    },
+    "securityMarks": {
+      "name": "organizations/1050000000008/sources/1986930501000008034/findings/047db1bc23a4b1fb00cbaa79b468945a/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2019-10-18T15:30:22.082Z"
+      }
+    },
+    "eventTime": "2019-10-18T15:30:22.082Z",
+    "createTime": "2019-10-18T15:31:58.487Z"
+  }
+}

--- a/cloudfunctions/router/testdata/non_org_iam_member.json
+++ b/cloudfunctions/router/testdata/non_org_iam_member.json
@@ -1,0 +1,26 @@
+{
+  "finding": {
+    "name": "organizations/1050000000008/sources/1986930501000008034/findings/047db1bc23a4b1fb00cbaa79b468945a",
+    "parent": "organizations/1050000000008/sources/1986930501000008034",
+    "resourceName": "//cloudresourcemanager.googleapis.com/projects/72300000536",
+    "state": "ACTIVE",
+    "category": "NON_ORG_IAM_MEMBER",
+    "externalUri": "https://console.cloud.google.com/iam-admin/iam?project=test-project",
+    "sourceProperties": {
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_non_org_iam_member\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "SeverityLevel": "High",
+      "Recommendation": "Go to https://console.cloud.google.com/iam-admin/iam?project=test-project and remove entries for users which are not in your organization (e.g. gmail.com addresses).",
+      "ProjectId": "test-project",
+      "AssetCreationTime": "2019-02-26T15:41:40.726Z",
+      "ScannerName": "IAM_SCANNER",
+      "ScanRunId": "2019-10-18T08:30:22.082-07:00",
+      "Explanation": "A user outside of your organization has IAM permissions on a project or organization."
+    },
+    "securityMarks": {
+      "name": "organizations/1050000000008/sources/1986930501000008034/findings/047db1bc23a4b1fb00cbaa79b468945a/securityMarks"
+    },
+    "eventTime": "2019-10-18T15:30:22.082Z",
+    "createTime": "2019-10-18T15:31:58.487Z"
+  }
+}

--- a/cloudfunctions/router/testdata/open_firewall-remediated.json
+++ b/cloudfunctions/router/testdata/open_firewall-remediated.json
@@ -1,0 +1,78 @@
+{
+  "notificationConfigName": "organizations/0000000000/notificationConfigs/sampleConfigId",
+  "finding": {
+    "access": {},
+    "assetDisplayName": "open-cassandra-port-tcp-7199",
+    "assetId": "organizations/0000000000/assets/17891988241833004615",
+    "canonicalName": "projects/12345678/sources/0000000/findings/2087237f91e4904e344a624c98e52ae6",
+    "category": "OPEN_FIREWALL",
+    "createTime": "2019-11-16T03:45:50.400Z",
+    "eventTime": "2021-06-01T14:57:33.426Z",
+    "externalUri": "https://console.cloud.google.com/networking/firewalls/details/open-cassandra-port-tcp-7199?project=test-project",
+    "findingClass": "MISCONFIGURATION",
+    "findingProviderId": "organizations/0000000000/firstPartyFindingProviders/security_health_advisor",
+    "indicator": {},
+    "mitreAttack": {},
+    "mute": "UNDEFINED",
+    "name": "organizations/0000000000/sources/0000000/findings/2087237f91e4904e344a624c98e52ae6",
+    "parent": "organizations/0000000000/sources/0000000",
+    "severity": "HIGH",
+    "sourceDisplayName": "Security Health Analytics",
+    "state": "ACTIVE",
+    "vulnerability": {},
+    "resource": {
+      "name": "//compute.googleapis.com/projects/test-project/global/firewalls/4695668982209007936",
+      "display_name": "open-cassandra-port-tcp-7199",
+      "project_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "project_display_name": "test-project",
+      "parent_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "parent_display_name": "test-project",
+      "type": "google.compute.Firewall",
+      "folders": [
+        {
+          "resourceFolder": "//cloudresourcemanager.googleapis.com/folders/987654321"
+        }
+      ]
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/2087237f91e4904e344a624c98e52ae6/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2021-06-01T14:57:33.426Z"
+      }
+    },
+    "sourceProperties": {
+      "Recommendation": "Restrict the firewall rules at: https://console.cloud.google.com/networking/firewalls/details/open-cassandra-port-tcp-7199?project=test-project",
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_open_firewall\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "Firewall rules that allow connections from all IP addresses or on all ports may expose resources to attackers.",
+      "ScannerName": "FIREWALL_SCANNER",
+      "ResourcePath": [
+        "projects/test-project/",
+        "folders/987654321/",
+        "organizations/0000000000/"
+      ],
+      "compliance_standards": {
+        "pci": [
+          {
+            "ids": [
+              "1.2.1"
+            ]
+          }
+        ]
+      },
+      "AllowedIpRange": "All",
+      "ActivationTrigger": "Allows all IP addresses",
+      "ExternalSourceRanges": [
+        "0.0.0.0/0"
+      ],
+      "ExternallyAccessibleProtocolsAndPorts": [
+        {
+          "IPProtocol": "tcp",
+          "ports": [
+            "7199"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cloudfunctions/router/testdata/open_rdp_port-remediated.json
+++ b/cloudfunctions/router/testdata/open_rdp_port-remediated.json
@@ -1,0 +1,97 @@
+{
+  "finding": {
+    "access": {},
+    "assetDisplayName": "default-allow-rdp",
+    "assetId": "organizations/0000000000/assets/9439544858484562111",
+    "canonicalName": "projects/12345678/sources/0000000/findings/5cc27561f6040c8570077e348a962c77",
+    "category": "OPEN_RDP_PORT",
+    "createTime": "2021-02-10T20:00:16.994Z",
+    "eventTime": "2021-06-05T14:54:49.731Z",
+    "externalUri": "https://console.cloud.google.com/networking/firewalls/details/default-allow-rdp?project=test-project",
+    "findingClass": "MISCONFIGURATION",
+    "findingProviderId": "organizations/0000000000/firstPartyFindingProviders/security_health_advisor",
+    "indicator": {},
+    "mitreAttack": {},
+    "mute": "UNDEFINED",
+    "name": "organizations/0000000000/sources/0000000/findings/5cc27561f6040c8570077e348a962c77",
+    "parent": "organizations/0000000000/sources/0000000",
+    "severity": "HIGH",
+    "sourceDisplayName": "Security Health Analytics",
+    "state": "ACTIVE",
+    "vulnerability": {},
+    "workflowState": "NEW",
+    "resource": {
+      "name": "//compute.googleapis.com/projects/test-project/global/firewalls/43256709",
+      "display_name": "default-allow-rdp",
+      "project_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "project_display_name": "test-project",
+      "parent_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "parent_display_name": "test-project",
+      "type": "google.compute.Firewall",
+      "folders": []
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/5cc27561f6040c8570077e348a962c77/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2021-06-05T14:54:49.731Z"
+      }
+    },
+    "sourceProperties": {
+      "Recommendation": "Restrict the firewall rules at: https://console.cloud.google.com/networking/firewalls/details/default-allow-rdp?project=test-project",
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_open_rdp_port\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "Firewall rules that allow connections from all IP addresses on TCP port 3389 or UDP port 3389 may expose RDP services to attackers.",
+      "ScannerName": "FIREWALL_SCANNER",
+      "ResourcePath": [
+        "projects/test-project/",
+        "organizations/0000000000/"
+      ],
+      "compliance_standards": {
+        "iso": [
+          {
+            "ids": [
+              "A.13.1.1"
+            ]
+          }
+        ],
+        "pci": [
+          {
+            "ids": [
+              "1.2.1"
+            ]
+          }
+        ],
+        "cis": [
+          {
+            "version": "1.0",
+            "ids": [
+              "3.7"
+            ]
+          },
+          {
+            "version": "1.1",
+            "ids": [
+              "3.7"
+            ]
+          }
+        ],
+        "nist": [
+          {
+            "ids": [
+              "SC-7"
+            ]
+          }
+        ]
+      },
+      "ExposedService": "RDP",
+      "OpenPorts": {
+        "TCP": [
+          3389
+        ],
+        "UDP": [
+          3389
+        ]
+      }
+    }
+  }
+}

--- a/cloudfunctions/router/testdata/open_ssh_port-remediated.json
+++ b/cloudfunctions/router/testdata/open_ssh_port-remediated.json
@@ -1,0 +1,97 @@
+{
+  "finding": {
+    "access": {},
+    "assetDisplayName": "default-allow-ssh",
+    "assetId": "organizations/0000000000/assets/16204382262521789065",
+    "canonicalName": "projects/12345678/sources/0000000/findings/2c976b5197e9648a9f64c4a21b4d5333",
+    "category": "OPEN_SSH_PORT",
+    "createTime": "2021-02-10T20:00:17.134Z",
+    "eventTime": "2021-06-14T14:55:34.789Z",
+    "externalUri": "https://console.cloud.google.com/networking/firewalls/details/default-allow-ssh?project=test-project",
+    "findingClass": "MISCONFIGURATION",
+    "findingProviderId": "organizations/0000000000/firstPartyFindingProviders/security_health_advisor",
+    "indicator": {},
+    "mitreAttack": {},
+    "mute": "UNDEFINED",
+    "name": "organizations/0000000000/sources/0000000/findings/2c976b5197e9648a9f64c4a21b4d5333",
+    "parent": "organizations/0000000000/sources/0000000",
+    "severity": "HIGH",
+    "sourceDisplayName": "Security Health Analytics",
+    "state": "ACTIVE",
+    "vulnerability": {},
+    "workflowState": "NEW",
+    "resource": {
+      "name": "//compute.googleapis.com/projects/test-project/global/firewalls/43256709",
+      "display_name": "default-allow-ssh",
+      "project_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "project_display_name": "test-project",
+      "parent_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "parent_display_name": "test-project",
+      "type": "google.compute.Firewall",
+      "folders": []
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/2c976b5197e9648a9f64c4a21b4d5333/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2021-06-14T14:55:34.789Z"
+      }
+    },
+    "sourceProperties": {
+      "Recommendation": "Restrict the firewall rules at: https://console.cloud.google.com/networking/firewalls/details/default-allow-ssh?project=test-project",
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_open_ssh_port\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "Firewall rules that allow connections from all IP addresses on TCP port 22 or SCTP port 22 may expose SSH services to attackers.",
+      "ScannerName": "FIREWALL_SCANNER",
+      "ResourcePath": [
+        "projects/test-project/",
+        "organizations/0000000000/"
+      ],
+      "compliance_standards": {
+        "iso": [
+          {
+            "ids": [
+              "A.13.1.1"
+            ]
+          }
+        ],
+        "pci": [
+          {
+            "ids": [
+              "1.2.1"
+            ]
+          }
+        ],
+        "cis": [
+          {
+            "version": "1.0",
+            "ids": [
+              "3.6"
+            ]
+          },
+          {
+            "version": "1.1",
+            "ids": [
+              "3.6"
+            ]
+          }
+        ],
+        "nist": [
+          {
+            "ids": [
+              "SC-7"
+            ]
+          }
+        ]
+      },
+      "ExposedService": "SSH",
+      "OpenPorts": {
+        "TCP": [
+          22
+        ],
+        "SCTP": [
+          22
+        ]
+      }
+    }
+  }
+}

--- a/cloudfunctions/router/testdata/public_bucket_acl-remediated.json
+++ b/cloudfunctions/router/testdata/public_bucket_acl-remediated.json
@@ -1,0 +1,30 @@
+{
+  "notificationConfigName": "organizations/154584661726/notificationConfigs/sampleConfigId",
+  "finding": {
+    "name": "organizations/154584661726/sources/2673592633662526977/findings/782e52631d61da6117a3772137c270d8",
+    "parent": "organizations/154584661726/sources/2673592633662526977",
+    "resourceName": "//storage.googleapis.com/this-is-public-on-purpose",
+    "state": "ACTIVE",
+    "category": "PUBLIC_BUCKET_ACL",
+    "externalUri": "https://console.cloud.google.com/storage/browser/this-is-public-on-purpose",
+    "sourceProperties": {
+      "ReactivationCount": 0.0,
+      "ExceptionInstructions": "Add the security mark \"allow_public_bucket_acl\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "SeverityLevel": "High",
+      "Recommendation": "Go to https://console.cloud.google.com/storage/browser/this-is-public-on-purpose, click on the Permissions tab, and remove \"allUsers\" and \"allAuthenticatedUsers\" from the bucket's members.",
+      "ProjectId": "test-project",
+      "AssetCreationTime": "2019-09-19T20:08:29.102Z",
+      "ScannerName": "STORAGE_SCANNER",
+      "ScanRunId": "2019-09-23T10:20:27.204-07:00",
+      "Explanation": "This bucket is public and can be accessed by anyone on the Internet. \"allUsers\" represents anyone on the Internet, and \"allAuthenticatedUsers\" represents anyone who is authenticated with a Google account; neither is constrained to users within your organization."
+    },
+    "securityMarks": {
+      "name": "organizations/154584661726/sources/2673592633662526977/findings/782e52631d61da6117a3772137c270d8/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2019-09-23T17:20:27.204Z"
+      }
+    },
+    "eventTime": "2019-09-23T17:20:27.204Z",
+    "createTime": "2019-09-23T17:20:27.934Z"
+  }
+}

--- a/cloudfunctions/router/testdata/public_bucket_acl.json
+++ b/cloudfunctions/router/testdata/public_bucket_acl.json
@@ -1,0 +1,30 @@
+{
+  "notificationConfigName": "organizations/154584661726/notificationConfigs/sampleConfigId",
+  "finding": {
+    "name": "organizations/154584661726/sources/2673592633662526977/findings/782e52631d61da6117a3772137c270d8",
+    "parent": "organizations/154584661726/sources/2673592633662526977",
+    "resourceName": "//storage.googleapis.com/this-is-public-on-purpose",
+    "state": "ACTIVE",
+    "category": "PUBLIC_BUCKET_ACL",
+    "externalUri": "https://console.cloud.google.com/storage/browser/this-is-public-on-purpose",
+    "sourceProperties": {
+      "ReactivationCount": 0.0,
+      "ExceptionInstructions": "Add the security mark \"allow_public_bucket_acl\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "SeverityLevel": "High",
+      "Recommendation": "Go to https://console.cloud.google.com/storage/browser/this-is-public-on-purpose, click on the Permissions tab, and remove \"allUsers\" and \"allAuthenticatedUsers\" from the bucket's members.",
+      "ProjectId": "test-project",
+      "AssetCreationTime": "2019-09-19T20:08:29.102Z",
+      "ScannerName": "STORAGE_SCANNER",
+      "ScanRunId": "2019-09-23T10:20:27.204-07:00",
+      "Explanation": "This bucket is public and can be accessed by anyone on the Internet. \"allUsers\" represents anyone on the Internet, and \"allAuthenticatedUsers\" represents anyone who is authenticated with a Google account; neither is constrained to users within your organization."
+    },
+    "securityMarks": {
+      "name": "organizations/154584661726/sources/2673592633662526977/findings/782e52631d61da6117a3772137c270d8/securityMarks",
+      "marks": {
+	"babab": "3"
+      }
+    },
+    "eventTime": "2019-09-23T17:20:27.204Z",
+    "createTime": "2019-09-23T17:20:27.934Z"
+  }
+}

--- a/cloudfunctions/router/testdata/public_dataset-remediated.json
+++ b/cloudfunctions/router/testdata/public_dataset-remediated.json
@@ -1,0 +1,30 @@
+{
+  "notificationConfigName": "organizations/154584661726/notificationConfigs/sampleConfigId",
+  "finding": {
+    "name": "organizations/154584661726/sources/7086426792249889955/findings/8682cf07ec50f921172082270bdd96e7",
+    "parent": "organizations/154584661726/sources/7086426792249889955",
+    "resourceName": "//bigquery.googleapis.com/projects/test-project/datasets/public_dataset123",
+    "state": "ACTIVE",
+    "category": "PUBLIC_DATASET",
+    "externalUri": "https://console.cloud.google.com/bigquery?project=test-project&folder&organizationId=154584661726&p=test-project&d=public_dataset123&page=dataset",
+    "sourceProperties": {
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_public_dataset\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "SeverityLevel": "High",
+      "Recommendation": "Go to https://console.cloud.google.com/bigquery?project=test-project&folder&organizationId=154584661726&p=test-project&d=public_dataset123&page=dataset, click \"SHARE DATASET\", search members for \"allUsers\" and \"allAuthenticatedUsers\",  and remove access for those members.",
+      "ProjectId": "test-project",
+      "AssetCreationTime": "2019-10-02T18:28:42.182Z",
+      "ScannerName": "DATASET_SCANNER",
+      "ScanRunId": "2019-10-03T11:40:22.538-07:00",
+      "Explanation": "This dataset is public and can be accessed by anyone on the Internet. \"allUsers\" represents anyone on the Internet, and \"allAuthenticatedUsers\" represents anyone who is authenticated with a Google account; neither is constrained to users within your organization."
+    },
+    "securityMarks": {
+      "name": "organizations/154584661726/sources/7086426792249889955/findings/8682cf07ec50f921172082270bdd96e7/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2019-10-03T18:40:22.538Z"
+      }
+    },
+    "eventTime": "2019-10-03T18:40:22.538Z",
+    "createTime": "2019-10-03T18:40:23.445Z"
+  }
+}

--- a/cloudfunctions/router/testdata/public_dataset.json
+++ b/cloudfunctions/router/testdata/public_dataset.json
@@ -1,0 +1,27 @@
+{
+  "notificationConfigName": "organizations/154584661726/notificationConfigs/sampleConfigId",
+  "finding": {
+    "name": "organizations/154584661726/sources/7086426792249889955/findings/8682cf07ec50f921172082270bdd96e7",
+    "parent": "organizations/154584661726/sources/7086426792249889955",
+    "resourceName": "//bigquery.googleapis.com/projects/test-project/datasets/public_dataset123",
+    "state": "ACTIVE",
+    "category": "PUBLIC_DATASET",
+    "externalUri": "https://console.cloud.google.com/bigquery?project=test-project&folder&organizationId=154584661726&p=test-project&d=public_dataset123&page=dataset",
+    "sourceProperties": {
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_public_dataset\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "SeverityLevel": "High",
+      "Recommendation": "Go to https://console.cloud.google.com/bigquery?project=test-project&folder&organizationId=154584661726&p=test-project&d=public_dataset123&page=dataset, click \"SHARE DATASET\", search members for \"allUsers\" and \"allAuthenticatedUsers\",  and remove access for those members.",
+      "ProjectId": "test-project",
+      "AssetCreationTime": "2019-10-02T18:28:42.182Z",
+      "ScannerName": "DATASET_SCANNER",
+      "ScanRunId": "2019-10-03T11:40:22.538-07:00",
+      "Explanation": "This dataset is public and can be accessed by anyone on the Internet. \"allUsers\" represents anyone on the Internet, and \"allAuthenticatedUsers\" represents anyone who is authenticated with a Google account; neither is constrained to users within your organization."
+    },
+    "securityMarks": {
+      "name": "organizations/154584661726/sources/7086426792249889955/findings/8682cf07ec50f921172082270bdd96e7/securityMarks"
+    },
+    "eventTime": "2019-10-03T18:40:22.538Z",
+    "createTime": "2019-10-03T18:40:23.445Z"
+  }
+}

--- a/cloudfunctions/router/testdata/public_ip_address-remediated.json
+++ b/cloudfunctions/router/testdata/public_ip_address-remediated.json
@@ -1,0 +1,85 @@
+{
+  "finding": {
+    "access": {},
+    "assetDisplayName": "integration-test-default-service-account-non-vuln-instance",
+    "assetId": "organizations/0000000000/assets/9992102437510379842",
+    "canonicalName": "projects/12345678/sources/0000000/findings/7b7bcfcc8597d2f8a3b7eddcb14f0ed6",
+    "category": "PUBLIC_IP_ADDRESS",
+    "createTime": "2022-01-08T01:21:42.076Z",
+    "eventTime": "2022-01-08T01:21:41.578Z",
+    "externalUri": "https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/integration-test-default-service-account-non-vuln-instance?project=test-project",
+    "findingClass": "MISCONFIGURATION",
+    "findingProviderId": "organizations/0000000000/firstPartyFindingProviders/security_health_advisor",
+    "indicator": {},
+    "mitreAttack": {},
+    "mute": "UNDEFINED",
+    "name": "organizations/0000000000/sources/0000000/findings/7b7bcfcc8597d2f8a3b7eddcb14f0ed6",
+    "parent": "organizations/0000000000/sources/0000000",
+    "severity": "HIGH",
+    "sourceDisplayName": "Security Health Analytics",
+    "state": "ACTIVE",
+    "vulnerability": {},
+    "workflowState": "NEW",
+    "resource": {
+      "name": "//compute.googleapis.com/projects/test-project/zones/us-central1-a/instances/6796113316167375355",
+      "display_name": "integration-test-default-service-account-non-vuln-instance",
+      "project_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "project_display_name": "test-project",
+      "parent_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "parent_display_name": "test-project",
+      "type": "google.compute.Instance",
+      "folders": [
+        {
+          "resourceFolderDisplayName": "enabled_folder",
+          "resourceFolder": "//cloudresourcemanager.googleapis.com/folders/987654321"
+        }
+      ]
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/7b7bcfcc8597d2f8a3b7eddcb14f0ed6/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2022-01-08T01:21:41.578Z"
+      }
+    },
+    "sourceProperties": {
+      "Recommendation": "If this is unintended, please go to https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/integration-test-default-service-account-non-vuln-instance?project=test-project and click \"Edit\". For each interface under the \"Network interfaces\" heading, set \"External IP\" to \"None\", then click \"Done\" and \"Save\". If you would like to learn more about securing access to your infrastructure, see https://cloud.google.com/solutions/connecting-securely.",
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_public_ip_address\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "To reduce the attack surface, avoid assigning public IP addresses to your VMs. Stopped instances may still be flagged with a Public IP finding, e.g. if the network interfaces are configured to assign an ephemeral public IP on start. Ensure the network configurations for stopped instances do not include external access.",
+      "ScannerName": "COMPUTE_INSTANCE_SCANNER",
+      "ResourcePath": [
+        "projects/test-project/",
+        "folders/987654321/",
+        "organizations/0000000000/"
+      ],
+      "compliance_standards": {
+        "pci": [
+          {
+            "ids": [
+              "1.2.1"
+            ]
+          }
+        ],
+        "cis": [
+          {
+            "version": "1.1",
+            "ids": [
+              "4.9"
+            ]
+          }
+        ],
+        "nist": [
+          {
+            "ids": [
+              "CA-3",
+              "SC-7"
+            ]
+          }
+        ]
+      },
+      "VulnerableNetworkInterfaceNames": [
+        "nic0"
+      ]
+    }
+  }
+}

--- a/cloudfunctions/router/testdata/public_sql_instance-remediated.json
+++ b/cloudfunctions/router/testdata/public_sql_instance-remediated.json
@@ -1,0 +1,95 @@
+{
+  "finding": {
+    "access": {},
+    "assetDisplayName": "postgre-nossl-open-nobackup",
+    "assetId": "organizations/0000000000/assets/868897641785017066",
+    "canonicalName": "projects/12345678/sources/0000000/findings/a3c5065740814c03680baaa3ad81167d",
+    "category": "PUBLIC_SQL_INSTANCE",
+    "createTime": "2019-11-12T00:20:37.543Z",
+    "eventTime": "2021-06-17T17:21:50.215Z",
+    "externalUri": "https://console.cloud.google.com/sql/instances/postgre-nossl-open-nobackup/connections?project=test-project",
+    "findingClass": "MISCONFIGURATION",
+    "findingProviderId": "organizations/0000000000/firstPartyFindingProviders/security_health_advisor",
+    "indicator": {},
+    "mitreAttack": {},
+    "mute": "UNDEFINED",
+    "name": "organizations/0000000000/sources/0000000/findings/a3c5065740814c03680baaa3ad81167d",
+    "parent": "organizations/0000000000/sources/0000000",
+    "severity": "HIGH",
+    "sourceDisplayName": "Security Health Analytics",
+    "state": "ACTIVE",
+    "vulnerability": {},
+    "resource": {
+      "name": "//cloudsql.googleapis.com/projects/test-project/instances/postgre-nossl-open-nobackup",
+      "display_name": "postgre-nossl-open-nobackup",
+      "project_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "project_display_name": "test-project",
+      "parent_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "parent_display_name": "test-project",
+      "type": "google.cloud.sql.Instance",
+      "folders": [
+        {
+          "resourceFolder": "//cloudresourcemanager.googleapis.com/folders/987654321"
+        }
+      ]
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/a3c5065740814c03680baaa3ad81167d/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2021-06-17T17:21:50.215Z"
+      }
+    },
+    "sourceProperties": {
+      "Recommendation": "Restrict the authorized networks at https://console.cloud.google.com/sql/instances/postgre-nossl-open-nobackup/connections?project=test-project.",
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_public_sql_instance\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "You have added 0.0.0.0/0 as an allowed network. This prefix will allow any IPv4 client to pass the network firewall and make login attempts to your instance, including clients you did not intend to allow. Clients still need valid credentials to successfully log in to your instance. Learn more at: https://cloud.google.com/sql/docs/mysql/configure-ip",
+      "ScannerName": "SQL_SCANNER",
+      "ResourcePath": [
+        "projects/test-project/",
+        "folders/987654321/",
+        "organizations/0000000000/"
+      ],
+      "compliance_standards": {
+        "iso": [
+          {
+            "ids": [
+              "A.8.2.3",
+              "A.13.1.3",
+              "A.14.1.3"
+            ]
+          }
+        ],
+        "pci": [
+          {
+            "ids": [
+              "1.2.1"
+            ]
+          }
+        ],
+        "cis": [
+          {
+            "version": "1.0",
+            "ids": [
+              "6.2"
+            ]
+          },
+          {
+            "version": "1.1",
+            "ids": [
+              "6.5"
+            ]
+          }
+        ],
+        "nist": [
+          {
+            "ids": [
+              "CA-3",
+              "SC-7"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cloudfunctions/router/testdata/sql_no_root_password-remediated.json
+++ b/cloudfunctions/router/testdata/sql_no_root_password-remediated.json
@@ -1,0 +1,144 @@
+{
+  "finding": {
+    "access": {},
+    "assetDisplayName": "test-no-root-password",
+    "assetId": "organizations/0000000000/assets/12835266000444331259",
+    "canonicalName": "projects/12345678/sources/0000000/findings/4e85bb5cbe72b14c6dbfa9e5592cdc5f",
+    "category": "SQL_NO_ROOT_PASSWORD",
+    "compliances": [
+      {
+	"standard": "cis",
+	"version": "1.0",
+	"ids": [
+	  "6.3"
+	]
+      },
+      {
+	"standard": "cis",
+	"version": "1.1",
+	"ids": [
+	  "6.1.1"
+	]
+      },
+      {
+	"standard": "cis",
+	"version": "1.2",
+	"ids": [
+	  "6.1.1"
+	]
+      },
+      {
+	"standard": "pci",
+	"ids": [
+	  "2.1"
+	]
+      },
+      {
+	"standard": "nist",
+	"ids": [
+	  "AC-3"
+	]
+      },
+      {
+	"standard": "iso",
+	"ids": [
+	  "A.8.2.3",
+	  "A.9.4.2"
+	]
+      }
+    ],
+    "createTime": "2022-04-11T18:33:34.763Z",
+    "description": "MySql database instances should have a strong password set for the root account.",
+    "eventTime": "2022-04-11T18:33:33.351Z",
+    "externalUri": "https://console.cloud.google.com/sql/instances/test-no-root-password/users?project=test-project",
+    "findingClass": "MISCONFIGURATION",
+    "findingProviderId": "organizations/0000000000/firstPartyFindingProviders/security_health_advisor",
+    "indicator": {},
+    "mitreAttack": {},
+    "mute": "UNDEFINED",
+    "name": "organizations/0000000000/sources/0000000/findings/4e85bb5cbe72b14c6dbfa9e5592cdc5f",
+    "parent": "organizations/0000000000/sources/0000000",
+    "severity": "HIGH",
+    "sourceDisplayName": "Security Health Analytics",
+    "state": "ACTIVE",
+    "vulnerability": {},
+    "workflowState": "NEW",
+    "resource": {
+      "name": "//cloudsql.googleapis.com/projects/test-project/instances/test-no-root-password",
+      "display_name": "test-no-root-password",
+      "project_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "project_display_name": "test-project",
+      "parent_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "parent_display_name": "test-project",
+      "type": "google.cloud.sql.Instance",
+      "folders": [
+	{
+	  "resourceFolderDisplayName": "enabled_folder",
+	  "resourceFolder": "//cloudresourcemanager.googleapis.com/folders/987654321"
+	}
+      ]
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/4e85bb5cbe72b14c6dbfa9e5592cdc5f/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2022-04-11T18:33:33.351Z"
+      }
+    },
+    "sourceProperties": {
+      "Recommendation": "Go to https://console.cloud.google.com/sql/instances/test-no-root-password/users?project=test-project click the 3 dot icon next to the \"root\" user, select \"Change Password\", specify a new strong password, click \"OK\".",
+      "ExceptionInstructions": "Add the security mark \"allow_sql_no_root_password\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "MySql database instances should have a strong password set for the root account.",
+      "ScannerName": "SQL_SCANNER",
+      "ResourcePath": [
+	"projects/test-project/",
+	"folders/987654321/",
+	"organizations/0000000000/"
+      ],
+      "compliance_standards": {
+	"iso": [
+	  {
+	    "ids": [
+	      "A.8.2.3",
+	      "A.9.4.2"
+	    ]
+	  }
+	],
+	"pci": [
+	  {
+	    "ids": [
+	      "2.1"
+	    ]
+	  }
+	],
+	"cis": [
+	  {
+	    "version": "1.0",
+	    "ids": [
+	      "6.3"
+	    ]
+	  },
+	  {
+	    "version": "1.1",
+	    "ids": [
+	      "6.1.1"
+	    ]
+	  },
+	  {
+	    "version": "1.2",
+	    "ids": [
+	      "6.1.1"
+	    ]
+	  }
+	],
+	"nist": [
+	  {
+	    "ids": [
+	      "AC-3"
+	    ]
+	  }
+	]
+      },
+      "ReactivationCount": 0
+    }
+  }
+}

--- a/cloudfunctions/router/testdata/ssh_brute_force-remediated.json
+++ b/cloudfunctions/router/testdata/ssh_brute_force-remediated.json
@@ -1,0 +1,94 @@
+{
+  "finding": {
+    "name": "organizations/0000000000/sources/0000000/findings/12345",
+    "parent": "organizations/0000000000/sources/0000000",
+    "resourceName": "//cloudresourcemanager.googleapis.com/projects/12345678",
+    "state": "ACTIVE",
+    "category": "Brute Force: SSH",
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/12345/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "1970-01-01T00:00:00Z"
+      }
+    },
+    "sourceProperties": {
+      "evidence": [
+        {
+          "sourceLogId": {
+            "projectId": "test-project",
+            "timestamp": {
+              "nanos": 0.0,
+              "seconds": "65"
+            },
+            "insertId": "3",
+            "resourceContainer": "projects/test-project"
+          }
+        }
+      ],
+      "properties": {
+        "projectId": "test-project",
+        "zone": "us-west1-a",
+        "instanceId": "1234",
+        "attempts": [
+          {
+            "sourceIp": "192.0.2.100",
+            "username": "etd_tester",
+            "vmName": "instance-1",
+            "authResult": "SUCCESS"
+          },
+          {
+            "sourceIp": "192.0.2.100",
+            "username": "etd_tester",
+            "vmName": "instance-1",
+            "authResult": "FAIL"
+          },
+          {
+            "sourceIp": "192.0.2.100",
+            "username": "etd_tester-2",
+            "vmName": "instance-1",
+            "authResult": "FAIL"
+          }
+        ]
+      },
+      "detectionPriority": "HIGH",
+      "sourceId": {
+        "projectNumber": "6789",
+        "customerOrganizationNumber": "12345"
+      },
+      "contextUris": {
+        "mitreUri": {
+          "displayName": "MITRE Link",
+          "url": "https://attack.mitre.org/techniques/T1078/003/"
+        },
+        "cloudLoggingQueryUri": [
+          {
+            "displayName": "Cloud Logging Query Link",
+            "url": "https://console.cloud.google.com/logs/query;query=timestamp%3D%221970-01-01T00:01:05Z%22%0AinsertId%3D%223%22%0Aresource.labels.project_id%3D%22test-project%22?project=test-project"
+          }
+        ],
+        "relatedFindingUri": {
+          "displayName": "Related SSH Brute Force Findings",
+          "url": "https://console.cloud.google.com/security/command-center/findings?organizationId=12345&pageState=(%22cscc-inventory%22:(%22f%22:%22%255B%257B_22k_22_3A_22sourceProperties.detectionCategory.ruleName_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22ssh_brute_force_5C_22_22%257D_2C%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22%2528resourceName_3A_5C_5C_5C_22//cloudresourcemanager.googleapis.com/projects/12345678_5C_5C_5C_22%2529_5C_22_22%257D%255D%22))"
+        }
+      },
+      "detectionCategory": {
+        "technique": "brute_force",
+        "indicator": "flow_log",
+        "ruleName": "ssh_brute_force"
+      },
+      "affectedResources": [
+        {
+          "gcpResourceName": "//cloudresourcemanager.googleapis.com/projects/12345678"
+        }
+      ]
+    },
+    "mitreAttack": {
+      "primary_tactic": "INITIAL_ACCESS",
+      "primary_techniques": ["VALID_ACCOUNTS", "LOCAL_ACCOUNTS"]
+    },
+    "severity": "HIGH",
+    "findingClass": "THREAT",
+    "eventTime": "1970-01-01T00:00:00Z",
+    "createTime": "1970-01-01T00:00:00Z"
+  }
+}

--- a/cloudfunctions/router/testdata/ssl_not_enforced-remediated.json
+++ b/cloudfunctions/router/testdata/ssl_not_enforced-remediated.json
@@ -1,0 +1,90 @@
+{
+  "finding": {
+    "access": {},
+    "assetDisplayName": "test",
+    "assetId": "organizations/0000000000/assets/5205430297007135564",
+    "canonicalName": "projects/12345678/sources/0000000/findings/99aa4eb54551972f0d7d32187bb0122b",
+    "category": "SSL_NOT_ENFORCED",
+    "createTime": "2022-01-05T00:28:45.505Z",
+    "eventTime": "2022-01-05T00:28:45.356Z",
+    "externalUri": "https://console.cloud.google.com/sql/instances/test/connections?project=test-project",
+    "findingClass": "MISCONFIGURATION",
+    "findingProviderId": "organizations/0000000000/firstPartyFindingProviders/security_health_advisor",
+    "indicator": {},
+    "mitreAttack": {},
+    "mute": "UNDEFINED",
+    "name": "organizations/0000000000/sources/0000000/findings/99aa4eb54551972f0d7d32187bb0122b",
+    "parent": "organizations/0000000000/sources/0000000",
+    "severity": "HIGH",
+    "sourceDisplayName": "Security Health Analytics",
+    "state": "ACTIVE",
+    "vulnerability": {},
+    "workflowState": "NEW",
+    "resource": {
+      "name": "//cloudsql.googleapis.com/projects/test-project/instances/test",
+      "display_name": "test",
+      "project_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "project_display_name": "test-project",
+      "parent_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "parent_display_name": "test-project",
+      "type": "google.cloud.sql.Instance",
+      "folders": []
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/99aa4eb54551972f0d7d32187bb0122b/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2022-01-05T00:28:45.356Z"
+      }
+    },
+    "sourceProperties": {
+      "Recommendation": "Go to https://console.cloud.google.com/sql/instances/test/overview?project=test-project and verify that the instance is running by looking for a green checkmark icon next to the instance name. If it is not running, then click on the \"START\" button. (The instance must be running in order to perform the next remediation step, but need not remain running afterwards.) Go to https://console.cloud.google.com/sql/instances/test/connections?project=test-project and click the \"Allow only SSL connections\" button.",
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_ssl_not_enforced\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "To avoid leaking sensitive data in transit through unencrypted communications, all incoming connections to your SQL database instance should use SSL. Learn more at: https://cloud.google.com/sql/docs/mysql/configure-ssl-instance",
+      "ScannerName": "SQL_SCANNER",
+      "ResourcePath": [
+        "projects/test-project/",
+        "organizations/0000000000/"
+      ],
+      "compliance_standards": {
+        "iso": [
+          {
+            "ids": [
+              "A.8.2.3",
+              "A.13.2.1",
+              "A.14.1.3"
+            ]
+          }
+        ],
+        "pci": [
+          {
+            "ids": [
+              "4.1"
+            ]
+          }
+        ],
+        "cis": [
+          {
+            "version": "1.0",
+            "ids": [
+              "6.1"
+            ]
+          },
+          {
+            "version": "1.1",
+            "ids": [
+              "6.4"
+            ]
+          }
+        ],
+        "nist": [
+          {
+            "ids": [
+              "SC-7"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cloudfunctions/router/testdata/web_ui_enabled-remediated.json
+++ b/cloudfunctions/router/testdata/web_ui_enabled-remediated.json
@@ -1,0 +1,78 @@
+{
+  "finding": {
+    "access": {},
+    "assetDisplayName": "insecure-cluster-1",
+    "assetId": "organizations/0000000000/assets/16405759896410614897",
+    "canonicalName": "projects/12345678/sources/0000000/findings/809adea65212b9fe4c5b0de52bc43dea",
+    "category": "WEB_UI_ENABLED",
+    "createTime": "2019-11-12T02:29:37.637Z",
+    "eventTime": "2021-10-01T19:24:17.786Z",
+    "externalUri": "https://console.cloud.google.com/kubernetes/clusters/details/us-west1-a/insecure-cluster-1?project=test-project",
+    "findingClass": "MISCONFIGURATION",
+    "findingProviderId": "organizations/0000000000/firstPartyFindingProviders/security_health_advisor",
+    "indicator": {},
+    "mitreAttack": {},
+    "mute": "UNDEFINED",
+    "name": "organizations/0000000000/sources/0000000/findings/809adea65212b9fe4c5b0de52bc43dea",
+    "parent": "organizations/0000000000/sources/0000000",
+    "severity": "HIGH",
+    "sourceDisplayName": "Security Health Analytics",
+    "state": "ACTIVE",
+    "vulnerability": {},
+    "resource": {
+      "name": "//container.googleapis.com/projects/test-project/zones/us-west1-a/clusters/insecure-cluster-1",
+      "display_name": "insecure-cluster-1",
+      "project_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "project_display_name": "test-project",
+      "parent_name": "//cloudresourcemanager.googleapis.com/projects/12345678",
+      "parent_display_name": "test-project",
+      "type": "google.container.Cluster",
+      "folders": [
+        {
+          "resourceFolder": "//cloudresourcemanager.googleapis.com/folders/987654321"
+        }
+      ]
+    },
+    "securityMarks": {
+      "name": "organizations/0000000000/sources/0000000/findings/809adea65212b9fe4c5b0de52bc43dea/securityMarks",
+      "marks": {
+	"sra-remediated-event-time": "2021-10-01T19:24:17.786Z"
+      }
+    },
+    "sourceProperties": {
+      "Recommendation": "Go to https://console.cloud.google.com/kubernetes/clusters/details/us-west1-a/insecure-cluster-1?project=test-project. In the \"Features\" section, click on the edit icon in the \"Kubernetes dashboard\" row. In the dialog that appears, disable the feature and then click \"SAVE CHANGES\". Note that a cluster cannot be modified while it is reconfiguring itself.",
+      "ReactivationCount": 0,
+      "ExceptionInstructions": "Add the security mark \"allow_web_ui_enabled\" to the asset with a value of \"true\" to prevent this finding from being activated again.",
+      "Explanation": "The Kubernetes web UI is backed by a highly privileged Kubernetes Service Account, which can be abused if compromised. If you are already using the GCP console, the Kubernetes web UI extends your attack surface unnecessarily. Learn more about how to disable the Kubernetes web UI and other techniques for hardening your Kubernetes clusters at https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#disable_kubernetes_dashboard",
+      "ScannerName": "CONTAINER_SCANNER",
+      "ResourcePath": [
+        "projects/test-project/",
+        "folders/987654321/",
+        "organizations/0000000000/"
+      ],
+      "compliance_standards": {
+        "pci": [
+          {
+            "ids": [
+              "6.6"
+            ]
+          }
+        ],
+        "cis": [
+          {
+            "version": "1.0",
+            "ids": [
+              "7.6"
+            ]
+          },
+          {
+            "version": "1.0",
+            "ids": [
+              "6.10.1"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
The first commit splits existing router_test remediation test cases out into separate testdata/ files.  The second one adds missing remediation test cases for each other finding type.